### PR TITLE
Fixes #7939/BZ1148488: increase prominence of nutupane loading display.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -32,11 +32,6 @@
       <span class="nutupane-info" data-block="result-count" translate>Showing {{ detailsTable.rows.length }} of {{ detailsTable.resource.subtotal }} ({{ detailsTable.resource.total }} Total)</span>
     </div>
 
-    <div class="col-sm-2" ng-show="detailsTable.working">
-      <i class="icon-spinner icon-spin"></i>
-      <span translate>Working...</span>
-    </div>
-
     <div class="col-sm-4 fr">
       <div class="fr">
         <span class="nutupane-info fl" data-block="selection-summary">
@@ -55,7 +50,11 @@
         </span>
       </div>
     </div>
+  </div>
 
+  <div class="working-indicator text-center" ng-show="detailsTable.working">
+    <i class="icon-spinner icon-spin"></i>
+    <span translate>Working...</span>
   </div>
 
   <div class="nutupane" alch-table="detailsTable" nutupane-table>

--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -391,3 +391,7 @@ div.alch-dialog.open.info-value {
 .details-section {
   padding: 0 15px;
 }
+
+.working-indicator {
+  font-size: 200%;
+}


### PR DESCRIPTION
The nutupane-details loading indicator was small and not noticeable.  This
commit increases the prominence of the loading indicator.

http://projects.theforeman.org/issues/7939
https://bugzilla.redhat.com/show_bug.cgi?id=1148488
