### PR TITLE
Fixes #4546: Align table headers properly when scrollbar exists with sti...

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
@@ -26,10 +26,11 @@ angular.module('Bastion.components').directive('bstContainerScroll', ['$window',
                 var addScroll = function () {
                     var windowWidth = windowElement.width(),
                         windowHeight = windowElement.height(),
+                        scrollWidth = element.scrollWidth || 0,
                         offset = element.offset().top;
 
                     if (attrs.controlWidth) {
-                        element.find(attrs.controlWidth).width(windowWidth);
+                        element.find(attrs.controlWidth).width(windowWidth - scrollWidth);
                     }
                     element.outerHeight(windowHeight - offset);
                     element.height(windowHeight - offset);

--- a/app/assets/javascripts/bastion/components/nutupane-table.directive.js
+++ b/app/assets/javascripts/bastion/components/nutupane-table.directive.js
@@ -9,11 +9,12 @@
  *
  * @example
  */
-angular.module('Bastion.components').directive('nutupaneTable', ['$compile', function ($compile) {
+angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$window', function ($compile, $window) {
     return {
         restrict: 'A',
         link: function (scope, element) {
-            var originalTable, clonedTable, clonedThs;
+            var originalTable, clonedTable, clonedThs,
+                windowElement = angular.element($window);
 
             scope.$on("$stateChangeSuccess", function (event, newState, newParams, oldState) {
                 // Only clone the table if the collapsed value changed or it's the first time.
@@ -33,6 +34,7 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', fun
                 clonedTable.removeAttr("nutupane-table");
                 clonedTable.addClass("cloned-nutupane-table");
                 clonedTable.find('tbody').remove();
+                clonedTable.find('thead tr').append('<th class="table-header-spacer"></th>');
 
                 originalTable.find('thead').hide();
 
@@ -45,11 +47,25 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', fun
                     angular.element(rowSelect).remove();
                 }
 
+                windowElement.bind('resize', function () {
+                    if (element.find('[bst-container-scroll]').length > 0) {
+                        clonedTable.find('thead tr th:last-child').width(element.width() - element.find('[bst-container-scroll]')[0].scrollWidth);
+                    }
+                });
+
                 // Compile each cloned th individually with original th scope
                 // so sort will work.
                 clonedThs = element.find('.cloned-nutupane-table th');
                 angular.forEach(originalTable.find('th'), function (th, index) {
                     $compile(clonedThs[index])(angular.element(th).scope());
+                });
+
+                originalTable.bind("DOMNodeInserted", function () {
+                    windowElement.trigger('resize');
+                });
+
+                originalTable.bind("DOMNodeInsertedIntoDocument", function () {
+                    windowElement.trigger('resize');
                 });
             }
 

--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -88,6 +88,16 @@ td.row-select {
 
     }
 
+    .table-header-spacer {
+      width: 1px;
+      border-left: none;
+      padding: 0;
+    }
+
+    th:nth-last-child(2) {
+      border-right: none;
+    }
+
     td.active-row {
       background-color: lighten(@listhover_color, 8%);
       color: white;

--- a/test/components/bst-container-scroll.directive.test.js
+++ b/test/components/bst-container-scroll.directive.test.js
@@ -50,7 +50,9 @@ describe('Directive: bstContainerScroll', function() {
             tableWidth = table.width(),
             windowElement = angular.element(window);
 
-        windowElement.width('300px');
+        expect(table.width()).toNotEqual(windowElement.width());
+
+        table.width('300px');
         windowElement.trigger('resize');
 
         expect(table.width()).toEqual(windowElement.width());


### PR DESCRIPTION
...cky header.

This introduces the idea of adjusting the table width based on the scroll
width of the alch container scroll to prevent data from hiding behind the scroll bar.
Further, a blank table head is added to the table header to push the header
columns back to the left and properly align the grid.
