### PR TITLE
Fixes #8260/BZ1142763: break word on detail labels.

### DIFF
--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -149,16 +149,19 @@ td.row-select {
 }
 
 .info-label {
-  font-weight: 600;
   display: inline-block;
-  width: 25%;
+  font-weight: 600;
   vertical-align: top;
+  width: 25%;
+  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .info-value {
-  width: 69%;
   display: inline-block;
   padding-left: 4px;
+  width: 69%;
+  word-break: break-all;
   word-wrap: break-word;
 }
 
@@ -288,20 +291,6 @@ td.row-select {
   .action-context {
     width: 300px;
   }
-}
-
-.info-label {
-  font-weight: 600;
-  display: inline-block;
-  width: 25%;
-  vertical-align: top;
-}
-
-.info-value {
-  width: 69%;
-  display: inline-block;
-  padding-left: 4px;
-  word-wrap: break-word;
 }
 
 .select-action {


### PR DESCRIPTION
The detail labels are fixed width and long labels would overlap
the detail values.  This commit wraps the detail labels so there
is no overlap.

http://projects.theforeman.org/issues/8260
https://bugzilla.redhat.com/show_bug.cgi?id=1142763
