### PR TITLE
Refs #8265/BZ1154380: remove deselect all link from tables.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -41,13 +41,6 @@
       <div class="fr">
         <span class="nutupane-info fl" data-block="selection-summary">
           <span translate>{{ detailsTable.numSelected }} Selected</span>
-          <span>|</span>
-          <a class="deselect-action"
-             translate
-             ng-class="{ 'disabled-link' : detailsTable.numSelected == 0 }"
-             ng-click="detailsTable.selectAllResults(false)">
-            Deselect All
-          </a>
         </span>
 
         <span class="fl">

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -31,13 +31,6 @@
     <div class="fr">
       <div class="nutupane-info fl" ng-if="table.rowSelect">
         <span translate>{{ table.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : table.numSelected == 0 }"
-           ng-click="table.selectAllResults(false)">
-          Deselect All
-        </a>
       </div>
 
       <div class="fl">


### PR DESCRIPTION
Remove the deselect all link from tables as the checkbox on the
left side of the table is the expected control for selecting and
deselecting.

http://projects.theforeman.org/issues/8265
https://bugzilla.redhat.com/show_bug.cgi?id=1154380
