### PR TITLE
Load engine without expanded path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require File.expand_path("lib/bastion/engine", File.dirname(__FILE__))
+require 'bastion/engine'
 
 namespace :bastion do
 


### PR DESCRIPTION
This was causing Topological sort error between initializers.
Initializers were loaded twice for Bastion,
because the path in Rakefile was expanded differently than bastion was previously loaded.
That is caused by symlinks in the path.

@ehelms this was the problem I was asking about yesterday.
