### PR TITLE
refs #7904 - add autocomplete support for nutupane

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -115,6 +115,48 @@ angular.module('Bastion.components').factory('Nutupane',
                 return params;
             };
 
+            self.table.autocomplete = function (term) {
+                var data, promise, params;
+                if (resource.autocomplete) {
+                    params = self.getParams();
+                    params.search = term;
+                    data = resource.autocomplete(params);
+                } else {
+                    data = self.table.fetchAutocomplete(term);
+                }
+
+                promise = data.$promise;
+                if (promise) {
+                    return promise.then(function (data) {
+                        return self.table.transformScopedSearch(data);
+                    });
+                }
+                else {
+                    return data;
+                }
+            };
+
+            self.table.transformScopedSearch = function (results) {
+                var rows = [],
+                    categoriesFound = [];
+                angular.forEach(results, function (row) {
+                    if (row.category && row.category.length > 0) {
+                        if (categoriesFound.indexOf(row.category) === -1) {
+                            categoriesFound.push(row.category);
+                            rows.push({category: row.category, isCategory: true});
+                        }
+                    }
+                    rows.push(row);
+                });
+
+                return rows;
+            };
+
+            //Overridable by real controllers, but default to nothing
+            self.table.fetchAutocomplete = function () {
+                return [];
+            };
+
             self.enableSelectAllResults = function () {
                 self.table.selectAllResultsEnabled = true;
                 self.table.allResultsSelected = false;

--- a/app/assets/javascripts/bastion/components/typeahead-empty.directive.js
+++ b/app/assets/javascripts/bastion/components/typeahead-empty.directive.js
@@ -1,0 +1,42 @@
+/**
+ Copyright 2014 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+/**
+ * @ngdoc directive
+ * @name Bastion.components.directive:typeaheadEmpty
+ *
+ *
+ * @description
+ *  Used to support autocompletion on focus, not just after the user types a single character
+ *
+ * @example
+    <input
+    typeahead="item as item.label for item in table.autocomplete($viewValue)"
+    typeahead-empty />
+ */
+
+angular.module('Bastion.components').directive('typeaheadEmpty', function () {
+    return {
+        require: 'ngModel',
+        link: function (scope, element, attrs, modelCtrl) {
+            element.bind('focus', function () {
+                if (modelCtrl.$viewValue === undefined || modelCtrl.$viewValue === '') {
+                    modelCtrl.$setViewValue(' ');
+                }
+                else {
+                    modelCtrl.$setViewValue(modelCtrl.$viewValue);
+                }
+            });
+        }
+    };
+});

--- a/app/assets/javascripts/bastion/components/views/autocomplete-scoped-search.html
+++ b/app/assets/javascripts/bastion/components/views/autocomplete-scoped-search.html
@@ -1,0 +1,10 @@
+<i class='ui-autocomplete-category' ng-show="match.model.isCategory">
+  {{ match.model.category }}
+</i>
+
+<a ng-hide="match.model.isCategory">
+  <i class='ui-autocomplete-completed'>
+    {{ match.model.completed }}
+  </i>
+  {{ match.model.part }}
+</a>

--- a/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -20,7 +20,12 @@
                  class="form-control"
                  placeholder="{{ 'Search...' | translate }}"
                  ng-model="detailsTable.searchTerm"
-                 bst-on-enter="detailsTable.search(detailsTable.searchTerm)"/>
+                 bst-on-enter="detailsTable.search(detailsTable.searchTerm)"
+                 ng-trim="false"
+                 typeahead="item.label for item in detailsTable.autocomplete($viewValue)"
+                 typeahead-empty
+                 typeahead-template-url="widgets/views/autocomplete-scoped-search.html"/>
+
           <span class="input-group-btn">
             <button ng-click="detailsTable.search(detailsTable.searchTerm)" class="btn btn-default" type="button"><i class="icon-search"></i></button>
           </span>

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -16,8 +16,12 @@
         <input type="text"
                class="form-control"
                placeholder="{{ 'Search...' | translate }}"
+               bst-on-enter="table.search(table.searchTerm)"
                ng-model="table.searchTerm"
-               bst-on-enter="table.search(table.searchTerm)"/>
+               ng-trim="false"
+               typeahead="item.label for item in table.autocomplete($viewValue)"
+               typeahead-empty
+               typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
         <span class="input-group-btn">
           <button ng-click="table.search(table.searchTerm)" class="btn btn-default" type="button"><i class="icon-search"></i></button>
         </span>

--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -112,7 +112,6 @@ td.row-select {
   background: rgb(250, 250, 250);
   padding: 10px 15px 10px 0;
   border-bottom: 1px solid rgb(230, 230, 230);
-  overflow: auto;
 
   h2 { margin: 5px 0 0 0; }
 
@@ -123,6 +122,10 @@ td.row-select {
     input {
       margin-bottom: 0;
     }
+  }
+
+  .dropdown-menu {
+    width: 100%;
   }
 }
 

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -233,6 +233,39 @@ describe('Factory: Nutupane', function() {
             expect(results.included.search).toBe("FOO");
         });
 
+        it("provides a way to translate scoped search queries", function() {
+            var translated,
+                data = [{label: 'bar', category: 'foo'},
+                        {label: 'bar2', category: 'foo'}];
+
+            translated = nutupane.table.transformScopedSearch(data);
+            expect(translated.length).toBe(3);
+            expect(translated[0].isCategory).toBeTruthy();
+            expect(translated[0].category).toBe('foo');
+            expect(translated[1]).toBe(data[0]);
+            expect(translated[2]).toBe(data[1]);
+        });
+
+        it("autocompletes using the original resource if possible", function() {
+            var data;
+            Resource.autocomplete = function() {return ["foo"]};
+            spyOn(Resource, 'autocomplete').andCallThrough();
+
+            data = nutupane.table.autocomplete();
+            expect(Resource.autocomplete).toHaveBeenCalled();
+            expect(data[0]).toBe("foo");
+        });
+
+        it("autocompletes using fetchAutocomplete if resource doesn't support autocomplete", function() {
+            var data;
+            nutupane.table.fetchAutocomplete = function() {return ['bar']};
+            spyOn(nutupane.table, 'fetchAutocomplete').andCallThrough();
+
+            data = nutupane.table.autocomplete();
+            expect(nutupane.table.fetchAutocomplete).toHaveBeenCalled();
+            expect(data[0]).toBe("bar");
+        });
+
         describe("provides a way to sort the table", function() {
             it ("defaults the sort to ascending if the previous sort does not match the new sort.", function() {
                 var expectedParams = {sort_by: 'name', sort_order: 'ASC', search: '', page: 1};

--- a/test/components/typeahead-empty.directive.test.js
+++ b/test/components/typeahead-empty.directive.test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+describe('Directive: typeahead-empty', function() {
+    var scope,
+        compile,
+        element,
+        elementScope;
+
+
+    beforeEach(module(
+        'Bastion.components'
+    ));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_) {
+        compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    beforeEach(function() {
+        element = angular.element('<input ng-model="myInput" type="text" typeahead-empty />');
+
+        compile(element)(scope);
+        scope.$digest();
+
+        elementScope = element.isolateScope();
+    });
+
+    it("should adjust empty string", function() {
+        scope.myInput = '';
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe(' ');
+    });
+
+    it("should adjust undefined", function() {
+        scope.myInput = undefined;
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe(' ');
+    });
+
+    it("should not adjust otherss", function() {
+        scope.myInput = 'foo';
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe('foo');
+    });
+});


### PR DESCRIPTION
by default nutupane will use autocomplete from the resource
if it provides an autocomplete function.  Otherwise it will use a
fetchAutocomplete function that can be added to the nutupane.table
within the desired controller
