### PR TITLE
Fixes #8560: Allow fencing HTML and routes off via a feature flag.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.js
+++ b/app/assets/javascripts/bastion/bastion.js
@@ -25,6 +25,7 @@
 
 //= require "bastion/bastion.module"
 //= require "bastion/bastion-resource.factory"
+//= require "bastion/feature-flag.run"
 
 //= require "bastion/i18n/i18n.module"
 //= require "bastion/i18n/translate.service.js"

--- a/app/assets/javascripts/bastion/feature-flag.run.js
+++ b/app/assets/javascripts/bastion/feature-flag.run.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+
+(function () {
+
+    /**
+     * @ngdoc service
+     * @name Bastion.run:FeatureFlag
+     *
+     * @description
+     *   Handles checking if a given feature is enabled. Provides this functionality on
+     *   the root scope and also checks routes to send the user to a 403.
+     *
+     * @example
+     *   HTML:
+     *     <button class="btn btn-default"
+     *             ng-if="featureEnabled('custom_products')"
+     *             ui-sref="products.discovery.scan">
+     *       <i class="icon-screenshot"></i>
+     *       {{ "Repo Discovery" | translate }}
+     *     </button>
+     *
+     *   Routes:
+     *     state("products.discovery.create", {
+     *         url: '/products/discovery/scan/create',
+     *         feature: 'custom_products',
+     *         templateUrl: 'products/discovery/views/discovery-create.html',
+     *         controller: 'DiscoveryFormController'
+     *     })
+     */
+    function FeatureFlag($rootScope, $window, Features) {
+
+        $rootScope.featureEnabled = function (flag) {
+            var enabled = true;
+
+            if (Features[flag] !== undefined) {
+                enabled = Features[flag];
+            }
+
+            return enabled;
+        };
+
+        $rootScope.$on('$stateChangeStart', function (event, toState) {
+            var feature = toState.feature;
+
+            if (feature !== undefined && !$rootScope.featureEnabled(feature)) {
+                $window.location.href = '/katello/403';
+            }
+        });
+    }
+
+    angular
+        .module('Bastion')
+        .run(FeatureFlag);
+
+    FeatureFlag.$inject = ['$rootScope', '$window', 'Features'];
+
+})();

--- a/app/views/bastion/layouts/application.html.erb
+++ b/app/views/bastion/layouts/application.html.erb
@@ -16,6 +16,7 @@
 <% content_for(:javascripts) do %>
   <%= javascript_include_tag 'bastion/bastion' %>
   <script type="text/javascript">
+    angular.module('Bastion').value('Features', angular.fromJson(<%= SETTINGS[:features].nil? ? {} : SETTINGS[:features].to_json.html_safe %>));
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
     angular.module('Bastion').value('Permissions', angular.fromJson('<%= User.current.roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>'));


### PR DESCRIPTION
The feature flag can be set in the Foreman settings.yaml file or
in a plugin settings within config/settings.plugins.d directory. The
settings format is:

:features:
  :custom_products: false

See the feature flag documentation for how to use it within HTML
and on a route.
