### PR TITLE
Fixes #9041: only preserve search strings across states.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -159,17 +159,19 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
 
         // Set the current language
         gettextCatalog.currentLanguage = currentLocale;
-
         $rootScope.$on('$stateChangeStart',
             function () {
-            //save location.search so we can add it back after transition is done
-            this.locationSearch = $location.search();
-        });
+                //save location.search so we can add it back after transition is done
+                this.locationSearch = $location.search().search;
+            }
+        );
 
         $rootScope.$on('$stateChangeSuccess',
             function (event, toState, toParams, fromStateIn, fromParamsIn) {
                 //restore all query string parameters back to $location.search
-                $location.search(this.locationSearch);
+                if (this.locationSearch) {
+                    $location.search('search', this.locationSearch);
+                }
 
                 //Record our from state, so we can transition back there
                 if (!fromStateIn.abstract) {


### PR DESCRIPTION
Prior to this commit we were removing any query string
parameters provided by ui-sref to the state.  This commit
changes the logic so we only preserve and update the
$location.search (i.e. query string parameters) if there
is a search string.

http://projects.theforeman.org/issues/9041