### PR TITLE
Refs #9288: Lock to angular-rails-templates 0.1.2 to fix immutable index...

### DIFF
--- a/bastion.gemspec
+++ b/bastion.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "angular-rails-templates", "~> 0.1.3"
+  s.add_dependency "angular-rails-templates", "0.1.2"
   s.add_development_dependency "uglifier"
   s.add_development_dependency "less-rails", "~> 2.5.0"
 end


### PR DESCRIPTION
....

Immutable index errors occur when plugins are loaded prior to anything
that includes angular-rails-templates. This issue appears to be due to
a change to the a-r-t initializar.

See https://github.com/pitr/angular-rails-templates/issues/83