### PR TITLE
Fixes #9345: ensure selection of paths in IE, bz 1168457.

### DIFF
--- a/app/assets/javascripts/bastion/components/path-selector.directive.js
+++ b/app/assets/javascripts/bastion/components/path-selector.directive.js
@@ -39,13 +39,16 @@ angular.module('Bastion.components').directive('pathSelector',
             selectionRequired = attrs['selectionRequired'] ? attrs['selectionRequired'] === 'true' : true;
 
             scope.itemChanged = function (item) {
-                if (item && scope.mode === 'singleSelect') {
-                    if (item.selected || selectionRequired) {
-                        unselectActive();
-                        selectById(item.id);
-                        activeItemId = item.id;
-                    } else {
-                        ngModel.$setViewValue(undefined);
+                if (item && !item.disabled) {
+                    if (scope.mode === 'singleSelect') {
+                        item.selected = !item.selected;
+                        if (item.selected || selectionRequired) {
+                            unselectActive();
+                            selectById(item.id);
+                            activeItemId = item.id;
+                        } else {
+                            ngModel.$setViewValue(undefined);
+                        }
                     }
                 }
             };

--- a/app/assets/javascripts/bastion/components/views/path-selector.html
+++ b/app/assets/javascripts/bastion/components/views/path-selector.html
@@ -1,9 +1,9 @@
 
 <div class="path-selector" ng-repeat="path in paths">
   <ul class="path-list">
-    <li class="path-list-item" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
+    <li class="path-list-item" ng-click="itemChanged(item)" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
       <label class="path-list-item-label" ng-disabled="item.disabled" ng-class="{ active: item.selected }" ng-mouseenter="hover" ng-mouseleave="hover = false">
-        <input type="checkbox" ng-model="item.selected" ng-change="itemChanged(item)" ng-disabled="item.disabled"/>
+        <input type="checkbox" ng-model="item.selected" ng-checked="item.selected" ng-disabled="item.disabled"/>
         {{ item.name }}
       </label>
     </li>

--- a/test/components/path-selector.directive.test.js
+++ b/test/components/path-selector.directive.test.js
@@ -72,12 +72,9 @@ describe('Directive: pathSelector', function() {
     });
 
     it("should select both items if two items with the same id exist", function() {
-        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+        var path = element.find('.path-list:first .path-list-item:first');
 
-        checkbox.trigger('click');
-        checkbox.attr('checked', 'checked');
-        checkbox.prop('checked', true);
-
+        path.trigger('click');
         expect(element.find('.path-list:eq(1)').find('.path-list-item:first input').is(':checked')).toBe(true);
     });
 
@@ -104,14 +101,15 @@ describe('Directive: pathSelector', function() {
     });
 
     it ("should not unselect by default", function () {
-        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+        var path = element.find('.path-list:first .path-list-item:first'),
+            checkbox = path.find('input');
 
         expect(checkbox.is(':checked')).toBe(false);
 
-        checkbox.click();
+        path.click();
         expect(checkbox.is(':checked')).toBe(true);
 
-        checkbox.click();
+        path.click();
         expect(checkbox.is(':checked')).toBe(true);
     });
 


### PR DESCRIPTION
IE wasn't selecting paths properly when clicking, item.selected was
not being set to true when seleted.  This commit ensures that the
path is selected by setting item.selected manually.

http://projects.theforeman.org/issues/9345
https://bugzilla.redhat.com/show_bug.cgi?id=1168457