### PR TITLE
Fixes #9399: Allow plugins to add configuration entries.

### DIFF
--- a/app/views/bastion/layouts/application.html.erb
+++ b/app/views/bastion/layouts/application.html.erb
@@ -27,9 +27,7 @@
       admin: <%= User.current.admin %>
     });
     angular.module('Bastion').value('markActiveMenu', mark_active_menu);
-    angular.module('Bastion').constant('BastionConfig', {
-        markTranslated: <%= SETTINGS[:mark_translated] || false %>
-    });
+    angular.module('Bastion').constant('BastionConfig', angular.fromJson('<%= Bastion.config.to_json.html_safe %>'));
   </script>
   <% Bastion.plugins.each do |name, plugin| %>
     <%= javascript_include_tag(plugin[:javascript]) %>

--- a/lib/bastion.rb
+++ b/lib/bastion.rb
@@ -18,4 +18,16 @@ module Bastion
     @@plugins[plugin[:name]] = plugin
   end
 
+  def self.config
+    base_config = {
+      'markTranslated' => SETTINGS[:mark_translated] || false
+    }
+
+    Bastion.plugins.each do |name, plugin|
+      base_config.merge!(plugin[:config]) if plugin[:config]
+    end
+
+    base_config
+  end
+
 end


### PR DESCRIPTION
Plugins can add configuration that is loaded via BastionConfig by
specifying during declaration:

Bastion.register_plugin(
  :name => 'Foo',
  :config => {
    'myBar' => 'isFoo'
  }
)