### PR TITLE
Refs #9345: revert IE specific changes to path selector, BZ1168457.

### DIFF
--- a/app/assets/javascripts/bastion/components/path-selector.directive.js
+++ b/app/assets/javascripts/bastion/components/path-selector.directive.js
@@ -64,17 +64,13 @@ angular.module('Bastion.components').directive('pathSelector',
             }
 
             scope.itemChanged = function (item) {
-                if (item && !item.disabled) {
-                    item.selected = !item.selected;
-
-                    if (scope.mode === 'singleSelect') {
-                        if (item.selected || selectionRequired) {
-                            unselectActive();
-                            selectById(item.id);
-                            activeItemId = item.id;
-                        } else {
-                            ngModel.$setViewValue(undefined);
-                        }
+                if (item && scope.mode === 'singleSelect') {
+                    if (item.selected || selectionRequired) {
+                        unselectActive();
+                        selectById(item.id);
+                        activeItemId = item.id;
+                    } else {
+                        ngModel.$setViewValue(undefined);
                     }
                 }
             };

--- a/app/assets/javascripts/bastion/components/views/path-selector.html
+++ b/app/assets/javascripts/bastion/components/views/path-selector.html
@@ -2,7 +2,7 @@
   <ul class="path-list">
     <li class="path-list-item" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
       <label class="path-list-item-label" ng-disabled="item.disabled" ng-class="{ active: item.selected }" ng-mouseenter="hover" ng-mouseleave="hover = false">
-        <input type="checkbox" ng-click="itemChanged(item)" ng-model="item.selected" ng-checked="item.selected" ng-disabled="item.disabled"/>
+        <input type="checkbox" ng-model="item.selected" ng-change="itemChanged(item)" ng-disabled="item.disabled"/>
         {{ item.name }}
       </label>
     </li>

--- a/test/components/path-selector.directive.test.js
+++ b/test/components/path-selector.directive.test.js
@@ -15,7 +15,8 @@ describe('Directive: pathSelector', function() {
     var scope,
         compile,
         paths,
-        element;
+        element,
+        elementScope;
 
     beforeEach(module(
         'Bastion.components',
@@ -72,9 +73,12 @@ describe('Directive: pathSelector', function() {
     });
 
     it("should select both items if two items with the same id exist", function() {
-        var path = element.find('.path-list:first .path-list-item:first');
+        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
 
-        path.trigger('click');
+        checkbox.trigger('click');
+        checkbox.attr('checked', 'checked');
+        checkbox.prop('checked', true);
+
         expect(element.find('.path-list:eq(1)').find('.path-list-item:first input').is(':checked')).toBe(true);
     });
 
@@ -101,15 +105,14 @@ describe('Directive: pathSelector', function() {
     });
 
     it ("should not unselect by default", function () {
-        var path = element.find('.path-list:first .path-list-item:first'),
-            checkbox = path.find('input');
+        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
 
         expect(checkbox.is(':checked')).toBe(false);
 
-        path.click();
+        checkbox.click();
         expect(checkbox.is(':checked')).toBe(true);
 
-        path.click();
+        checkbox.click();
         expect(checkbox.is(':checked')).toBe(true);
     });
 


### PR DESCRIPTION
Commits cc61cf4 and c799764 introduced changes to the path-selector
that are not needed.  The issue was on the katello side and has been
addressed with https://github.com/Katello/katello/pull/5057.

http://projects.theforeman.org/issues/9345
https://bugzilla.redhat.com/show_bug.cgi?id=1168457