### PR TITLE
Fixes #5339: only display loading on refresh BZ 1199267.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -70,6 +70,11 @@ angular.module('Bastion.components').factory('Nutupane',
                 replace = replace || false;
                 table.working = true;
 
+                if (table.initialLoad) {
+                    table.refreshing = true;
+                    table.initialLoad = false;
+                }
+
                 params.page = table.resource.page + 1;
                 params.search = table.searchTerm || "";
                 params.search = self.searchTransform(params.search);
@@ -183,6 +188,7 @@ angular.module('Bastion.components').factory('Nutupane',
             };
 
             self.refresh = function () {
+                self.table.refreshing = true;
                 self.table.resource.page = 0;
                 return self.load(true);
             };
@@ -256,6 +262,7 @@ angular.module('Bastion.components').factory('Nutupane',
                 self.table.selectAllResults(false);
 
                 if (!self.table.working) {
+                    self.table.refreshing = true;
                     self.query();
                 }
             };

--- a/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -50,12 +50,11 @@
     </div>
   </div>
 
-  <div class="working-indicator text-center" ng-show="detailsTable.working">
-    <i class="fa fa-spinner icon-spin"></i>
-    <span translate>Working...</span>
-  </div>
-
   <div class="nutupane" bst-table="detailsTable" nutupane-table>
+    <div class="loading-mask loading-mask-collapsed" ng-show="detailsTable.refreshing">
+      <i class="fa fa-spinner fa-spin"></i>
+      <span ng-hide="$root.$state.current.collapsed">{{ "Loading..." | translate }}</span>
+    </div>
 
     <div bst-container-scroll bst-infinite-scroll="detailsTable.nextPage()"
          data="detailsTable.rows" skip-initial-load="!detailsTable.initialLoad">

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -52,7 +52,7 @@
   </div>
 
   <div class="row nutupane" bst-table="table" nutupane-table ng-class="{'table-reduced': $root.$state.current.collapsed}">
-    <div class="loading-mask" ng-show="table.working" ng-class="{ 'loading-mask-collapsed': $root.$state.current.collapsed }">
+    <div class="loading-mask" ng-show="table.refreshing" ng-class="{ 'loading-mask-collapsed': $root.$state.current.collapsed }">
       <i class="fa fa-spinner fa-spin"></i>
       <span ng-hide="$root.$state.current.collapsed">{{ "Loading..." | translate }}</span>
     </div>

--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -390,10 +390,6 @@ div.alch-dialog.open.info-value {
   padding: 0 15px;
 }
 
-.working-indicator {
-  font-size: 200%;
-}
-
 table .progress {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Only show the nutupane loading indicator on initial load, search,
and refresh instead of every time the rows are updated.

http://projects.theforeman.org/issues/5339
https://bugzilla.redhat.com/show_bug.cgi?id=1199267