### PR TITLE
Refs #9927: hide cloned table when no rows BZ1206611.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane-table.directive.js
+++ b/app/assets/javascripts/bastion/components/nutupane-table.directive.js
@@ -24,6 +24,7 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$w
                 originalTable = element.find('table');
                 clonedTable = originalTable.clone();
 
+                clonedTable.attr('ng-show', 'table.rows.length > 0');
                 clonedTable.removeAttr("nutupane-table");
                 clonedTable.addClass("cloned-nutupane-table");
                 clonedTable.find('tbody').remove();

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -19,7 +19,7 @@
     </div>
 
 
-    <div class="col-sm-3 nutupane-info">
+    <div class="col-sm-3 nutupane-info" ng-show="table.rows.length > 0">
       <div class="input-group input-group">
         <input type="text"
                class="form-control"


### PR DESCRIPTION
The cloned nutupane table was being shown when there
were no rows in the table.  This commit hides the cloned
table if there are no rows.

http://projects.theforeman.org/issues/9927
https://bugzilla.redhat.com/show_bug.cgi?id=1206611