### PR TITLE
Fixes #9930: hide cloned table when no rows.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane-table.directive.js
+++ b/app/assets/javascripts/bastion/components/nutupane-table.directive.js
@@ -14,6 +14,7 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$w
         restrict: 'A',
         link: function (scope, element) {
             var originalTable, clonedTable, clonedThs,
+                bstTableName = element.attr('bst-table'),
                 windowElement = angular.element($window);
 
             function buildTable() {
@@ -24,6 +25,11 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$w
                 originalTable = element.find('table');
                 clonedTable = originalTable.clone();
 
+                if (!bstTableName) {
+                    bstTableName = element.find('[bst-table]').attr('bst-table');
+                }
+
+                clonedTable.attr('ng-show', bstTableName + '.rows.length > 0');
                 clonedTable.removeAttr("nutupane-table");
                 clonedTable.addClass("cloned-nutupane-table");
                 clonedTable.find('tbody').remove();


### PR DESCRIPTION
The cloned nutupane table was being shown when there
were no rows in the table.  This commit hides the cloned
table if there are no rows.

http://projects.theforeman.org/issues/9930
See also:  https://bugzilla.redhat.com/show_bug.cgi?id=1206611