### PR TITLE
Fixes #9729: speed up nutupane by removing JS BZ 1161630.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-table.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-table.directive.js
@@ -3,12 +3,14 @@
  * @name Bastion.components.directive:bstTable
  * @restrict A
  *
+ * @requires $window
+ *
  * @description
  *
  * @example
  */
 angular.module('Bastion.components')
-    .directive('bstTable', [function () {
+    .directive('bstTable', ['$window', function ($window) {
         return {
             restrict: 'A',
             replace: true,
@@ -17,7 +19,22 @@ angular.module('Bastion.components')
                 'rowSelect': '@',
                 'rowChoice': '@'
             },
-            controller: 'BstTableController'
+            controller: 'BstTableController',
+            link: function (scope) {
+                var resize = function () {
+                    angular.element($window).trigger('resize');
+                };
+
+                // Trigger resize after resource $promise is resolved
+                scope.$watch('table.resource', function (resource) {
+                    if (resource && resource.hasOwnProperty('$promise')) {
+                        resource.$promise.then(resize);
+                    }
+                });
+
+                // Trigger resize when rows change
+                scope.$watch('table.rows', resize);
+            }
         };
     }])
     .controller('BstTableController', ['$scope', function ($scope) {

--- a/app/assets/javascripts/bastion/components/nutupane-table.directive.js
+++ b/app/assets/javascripts/bastion/components/nutupane-table.directive.js
@@ -52,14 +52,6 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$w
                 angular.forEach(originalTable.find('th'), function (th, index) {
                     $compile(clonedThs[index])(angular.element(th).scope());
                 });
-
-                originalTable.bind("DOMNodeInserted", function () {
-                    windowElement.trigger('resize');
-                });
-
-                originalTable.bind("DOMNodeInsertedIntoDocument", function () {
-                    windowElement.trigger('resize');
-                });
             }
 
             scope.$on("$stateChangeSuccess", function (event, newState, newParams, oldState) {


### PR DESCRIPTION
There was some non-performant JS that was causing nutupane
to be really slow when there were lots of rows in a table,
namely triggering resize on each row inserted into the table.
This commit replaces the slow JS with an approach that is more
in performant and more in line with Angular JS best practices.

http://projects.theforeman.org/issues/9729
https://bugzilla.redhat.com/show_bug.cgi?id=1161630