### PR TITLE
Fixes #8260: prevent wrapping text for info label and value, BZ1142763.

### DIFF
--- a/app/assets/stylesheets/bastion/nutupane.less
+++ b/app/assets/stylesheets/bastion/nutupane.less
@@ -167,12 +167,14 @@ td.row-select {
   font-weight: 600;
   vertical-align: top;
   width: 25%;
+  word-wrap: break-word;
 }
 
 .info-value {
   display: inline-block;
   padding-left: 4px;
   width: 69%;
+  word-wrap: break-word;
 }
 
 .info-paragraph {


### PR DESCRIPTION
Break lines on words to avoid overlap of long words on labels and values.

http://projects.theforeman.org/issues/8260
https://bugzilla.redhat.com/show_bug.cgi?id=1142763