### PR TITLE
Fixes #10502: ensure enough results to scroll on resize, BZ1206704.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-infinite-scroll.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-infinite-scroll.directive.js
@@ -9,6 +9,8 @@
  *   Note that the element using the bst-infinite-scroll directive should have it's overflow
  *   set properly.
  *
+ * @requires $window
+ *
  * @example
  *   <pre>
  *     <div bst-infinite-scroll="loadMore()" style="height: 100px; overflow-y: auto;">
@@ -16,7 +18,7 @@
  *     </div>
  *   </pre>
  */
-angular.module('Bastion.components').directive('bstInfiniteScroll', [function () {
+angular.module('Bastion.components').directive('bstInfiniteScroll', ['$window', function ($window) {
     return {
         scope: {
             data: '=',
@@ -25,7 +27,7 @@ angular.module('Bastion.components').directive('bstInfiniteScroll', [function ()
         },
         controller: function ($scope, $element) {
 
-            var result, getScrollHeight, isPromise, loadUntilScroll,
+            var getScrollHeight, isPromise, loadUntilScroll,
                 raw = $element[0];
 
             $element.bind('scroll', function () {
@@ -62,11 +64,10 @@ angular.module('Bastion.components').directive('bstInfiniteScroll', [function ()
                 }
             };
 
+            angular.element($window).bind('resize', loadUntilScroll);
+
             if (!$scope.skipInitialLoad && (angular.isUndefined($scope.data) || $scope.data.length === 0)) {
-                result = $scope.loadMoreFunction();
-                if (isPromise(result)) {
-                    result.then(loadUntilScroll);
-                }
+                loadUntilScroll();
             }
         }
     };

--- a/test/components/bst-infinite-scroll.directive.test.js
+++ b/test/components/bst-infinite-scroll.directive.test.js
@@ -17,7 +17,7 @@ describe('Directive: bstInfiniteScroll', function () {
             }
         };
         $scope.data = [];
-        element = angular.element('<div data="data" bst-infinite-scroll="scrollHandler.doIt()" style=" height: 100px; position: absolute; overflow-y: auto;"></div>');
+        element = angular.element('<div data="data" bst-infinite-scroll="scrollHandler.doIt()" style="height: 100px; position: absolute; overflow-y: auto;"></div>');
         $('body').append(element);
     }));
 
@@ -78,10 +78,12 @@ describe('Directive: bstInfiniteScroll', function () {
 
         it("loads more results if the scroll height is less than element height.", function() {
             spyOn($scope.scrollHandler, "doIt").andCallThrough();
-            element.height("9px");
+            element.height("11px");
 
             $compile(element)($scope);
             $scope.$digest();
+            $scope.$digest();
+
 
             expect($scope.scrollHandler.doIt.callCount).toBe(1);
         });
@@ -98,7 +100,7 @@ describe('Directive: bstInfiniteScroll', function () {
         });
 
         it("does not load more results if the scroll height is greater than the element height.", function() {
-            element.height("11px");
+            element.height("9px");
             element.append('<p style="height: 10px;"></p>');
             $compile(element)($scope);
 
@@ -106,6 +108,20 @@ describe('Directive: bstInfiniteScroll', function () {
             $scope.$digest();
 
             expect($scope.scrollHandler.doIt.callCount).toBe(0);
+        });
+
+        it("on resize", function() {
+            element.height("11px");
+            $compile(element)($scope);
+            $scope.$digest();
+            spyOn($scope.scrollHandler, "doIt").andCallThrough();
+
+            element.height("21px");
+            $(window).trigger('resize');
+            $scope.$digest();
+
+
+            expect($scope.scrollHandler.doIt.callCount).toBe(1);
         });
     });
 });


### PR DESCRIPTION
We were triggering the resize event when more rows are added but
were not ensuring that we load until scroll when that happens.  This
commit ensures that we load until there is a scrollbar.

http://projects.theforeman.org/issues/10502
https://bugzilla.redhat.com/show_bug.cgi?id=1206704