### PR TITLE
Fixes #10567: add back code to trigger initial load, BZ 1223562.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-infinite-scroll.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-infinite-scroll.directive.js
@@ -26,8 +26,7 @@ angular.module('Bastion.components').directive('bstInfiniteScroll', ['$window', 
             skipInitialLoad: '='
         },
         controller: function ($scope, $element) {
-
-            var getScrollHeight, isPromise, loadUntilScroll,
+            var result, getScrollHeight, isPromise, loadUntilScroll,
                 raw = $element[0];
 
             $element.bind('scroll', function () {
@@ -67,7 +66,10 @@ angular.module('Bastion.components').directive('bstInfiniteScroll', ['$window', 
             angular.element($window).bind('resize', loadUntilScroll);
 
             if (!$scope.skipInitialLoad && (angular.isUndefined($scope.data) || $scope.data.length === 0)) {
-                loadUntilScroll();
+                result = $scope.loadMoreFunction();
+                if (isPromise(result)) {
+                    result.then(loadUntilScroll);
+                }
             }
         }
     };


### PR DESCRIPTION
Firefox apparently doesn't trigger a resize event on page load
and chrome does.  The changes in ecf1756d were relying on this
initial resize event to load the results.  This commit adds
back the inital load.

http://projects.theforeman.org/issues/10567
https://bugzilla.redhat.com/show_bug.cgi?id=1223562