### PR TITLE
Fixes #10515: check if scroll is needed after results are loaded.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -5,6 +5,7 @@
  * @requires $location
  * @requires $q
  * @requires $timeout
+ * @requires $rootScope
  *
  * @description
  *   Defines the Nutupane factory for adding common functionality to the Nutupane master-detail
@@ -28,7 +29,7 @@
     </pre>
  */
 angular.module('Bastion.components').factory('Nutupane',
-    ['$location', '$q', '$timeout', function ($location, $q, $timeout) {
+    ['$location', '$q', '$timeout', '$rootScope', function ($location, $q, $timeout, $rootScope) {
         var Nutupane = function (resource, params, action) {
             var self = this;
             params = params || {};
@@ -95,6 +96,8 @@ angular.module('Bastion.components').factory('Nutupane',
                             table.selectAll(true);
                         }
                         table.resource.offset = table.rows.length;
+
+                        $rootScope.$emit('nutupane:loaded');
                     }, 0);
                     table.working = false;
                     table.refreshing = false;

--- a/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -72,7 +72,7 @@
         <span data-block="no-rows-message"></span>
       </p>
 
-      <div infinite-scroll="detailsTable.nextPage()" infinite-scroll-container="'.nutupane-details-table .container-scroll-wrapper'">
+      <div infinite-scroll="detailsTable.nextPage()" infinite-scroll-container="'.nutupane-details-table .container-scroll-wrapper'" infinite-scroll-listen-for-event="nutupane:loaded">
         <div ng-show="detailsTable.rows.length > 0" data-block="table"></div>
       </div>
     </div>

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -62,7 +62,8 @@
     </p>
 
     <div ng-show="table.rows.length > 0" bst-container-scroll data="table.rows">
-      <div infinite-scroll="table.nextPage()" infinite-scroll-container="'.container-scroll-wrapper'" ui-view="table"></div>
+      <div infinite-scroll="table.nextPage()" infinite-scroll-container="'.container-scroll-wrapper'" infinite-scroll-listen-for-event="nutupane:loaded"
+           ui-view="table"></div>
     </div>
   </div>
 

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "angular-blocks": "~>0.1.8",
     "angular-i18n": "1.3.13",
     "underscore": "=1.5.2",
-    "ngInfiniteScroll": "1.2.0",
+    "ngInfiniteScroll": "1.2.1",
     "ngUpload": "~0.5.5",
     "bootstrap": "~3.1.1",
     "font-awesome": "4.2.0",

--- a/vendor/assets/javascripts/bastion/ngInfiniteScroll/ng-infinite-scroll.js
+++ b/vendor/assets/javascripts/bastion/ngInfiniteScroll/ng-infinite-scroll.js
@@ -1,4 +1,4 @@
-/* ng-infinite-scroll - v1.2.0 - 2014-12-02 */
+/* ng-infinite-scroll - v1.2.0 - 2015-02-14 */
 var mod;
 
 mod = angular.module('infinite-scroll', []);
@@ -13,10 +13,11 @@ mod.directive('infiniteScroll', [
         infiniteScrollContainer: '=',
         infiniteScrollDistance: '=',
         infiniteScrollDisabled: '=',
-        infiniteScrollUseDocumentBottom: '='
+        infiniteScrollUseDocumentBottom: '=',
+        infiniteScrollListenForEvent: '@'
       },
       link: function(scope, elem, attrs) {
-        var changeContainer, checkWhenEnabled, container, handleInfiniteScrollContainer, handleInfiniteScrollDisabled, handleInfiniteScrollDistance, handleInfiniteScrollUseDocumentBottom, handler, height, immediateCheck, offsetTop, pageYOffset, scrollDistance, scrollEnabled, throttle, useDocumentBottom, windowElement;
+        var changeContainer, checkWhenEnabled, container, handleInfiniteScrollContainer, handleInfiniteScrollDisabled, handleInfiniteScrollDistance, handleInfiniteScrollUseDocumentBottom, handler, height, immediateCheck, offsetTop, pageYOffset, scrollDistance, scrollEnabled, throttle, unregisterEventListener, useDocumentBottom, windowElement;
         windowElement = angular.element($window);
         scrollDistance = null;
         scrollEnabled = null;
@@ -24,6 +25,7 @@ mod.directive('infiniteScroll', [
         container = null;
         immediateCheck = true;
         useDocumentBottom = false;
+        unregisterEventListener = null;
         height = function(elem) {
           elem = elem[0] || elem;
           if (isNaN(elem.offsetHeight)) {
@@ -110,7 +112,11 @@ mod.directive('infiniteScroll', [
           handler = throttle(handler, THROTTLE_MILLISECONDS);
         }
         scope.$on('$destroy', function() {
-          return container.unbind('scroll', handler);
+          container.unbind('scroll', handler);
+          if (unregisterEventListener != null) {
+            unregisterEventListener();
+            return unregisterEventListener = null;
+          }
         });
         handleInfiniteScrollDistance = function(v) {
           return scrollDistance = parseFloat(v) || 0;
@@ -141,6 +147,9 @@ mod.directive('infiniteScroll', [
           }
         };
         changeContainer(windowElement);
+        if (scope.infiniteScrollListenForEvent) {
+          unregisterEventListener = $rootScope.$on(scope.infiniteScrollListenForEvent, handler);
+        }
         handleInfiniteScrollContainer = function(newContainer) {
           if ((newContainer == null) || newContainer.length === 0) {
             return;


### PR DESCRIPTION
After replacing our own infinite scroll with ngInfiniteScroll
we weren't checking to see if scroll was needed after nutupane
results were loaded.  This could cause the display of only one
set of results on larger screens.  This commit forces ngInfiniteScroll
to recheck if a scroll is needed after results are loaded.

http://projects.theforeman.org/issues/10515