### PR TITLE
fixes #11076 - fixes starred environments promotion suggestions

### DIFF
--- a/app/assets/javascripts/bastion/components/views/path-selector.html
+++ b/app/assets/javascripts/bastion/components/views/path-selector.html
@@ -3,7 +3,7 @@
     <li class="path-list-item" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
       <label class="path-list-item-label" ng-disabled="item.disabled" ng-class="{ active: item.selected }" ng-mouseenter="hover" ng-mouseleave="hover = false">
         <input type="checkbox" ng-model="item.selected" ng-change="itemChanged(item)" ng-disabled="item.disabled"/>
-          <span ng-class="{{ item.customClass }}">{{ item.name }}</span>
+          <span ng-class="item.customClass">{{ item.name }}</span>
       </label>
     </li>
   </ul>


### PR DESCRIPTION
This change is necessary because we were previously binding to the result of an expression instead of an expression itself. Thus, the ng-class directive would properly see the value of item.customClass but would not necessarily update based upon digest cycles.

with https://github.com/Katello/katello/pull/5444