### PR TITLE
Fixes #11831: wrap text in modal and alerts BZ1205047.

### DIFF
--- a/app/assets/stylesheets/bastion/bastion.less
+++ b/app/assets/stylesheets/bastion/bastion.less
@@ -1,3 +1,8 @@
+
+.modal-dialog {
+  word-wrap: break-word;
+}
+
 // Third-party Libraries
 //
 // Temporary namespace to prevent Boostrap3/RCUE from

--- a/app/assets/stylesheets/bastion/typography.less
+++ b/app/assets/stylesheets/bastion/typography.less
@@ -29,3 +29,7 @@ pre {
   border-radius: 3px;
   margin: 15px 5px;
 }
+
+.alert {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Ensure text is wrapped in modals and alerts by creating
and using a wordwrap mixin.

http://projects.theforeman.org/issues/11831
https://bugzilla.redhat.com/show_bug.cgi?id=1205047