### PR TITLE
Fixes #11289 - nutupane details pages use search get param for searching

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -353,6 +353,11 @@ angular.module('Bastion.components').factory('Nutupane',
                 self.table.rows = [];
                 self.query();
             };
+
+            self.setSearchKey = function (newKey) {
+                self.searchKey = newKey;
+                self.table.searchTerm = $location.search()[self.searchKey];
+            };
         };
         return Nutupane;
     }]

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -233,6 +233,11 @@ describe('Factory: Nutupane', function() {
             expect(translated[2]).toBe(data[1]);
         });
 
+        it("provides a way to change the searchKey", function() {
+            nutupane.setSearchKey("keyFoo");
+            expect(nutupane.searchKey).toBe("keyFoo");
+        });
+
         it("autocompletes using the original resource if possible", function() {
             var data;
             Resource.autocomplete = function() {return ["foo"]};


### PR DESCRIPTION
This allows the searchKey to be changed after nutupane is declared and would fix the "bleeding"  of search parameters when there are two search boxes in view. 

To test in katello on packages -> repositories tab:

```
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package-details-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package-details-repositories.controller.js
@@ -26,7 +26,7 @@ angular.module('Bastion.packages').controller('PackageDetailsRepositoriesControl
         $scope.detailsTable = repositoriesNutupane.table;
         $scope.detailsTable.initialLoad = false;
         repositoriesNutupane.masterOnly = true;
-        repositoriesNutupane.searchKey = 'repositoriesSearch';
+        repositoriesNutupane.replaceSearchKey('repositoriesSearch');
```