### PR TITLE
Fixes #12604 - update bastion routes for rails 4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,10 @@ Foreman::Application.routes.draw do
 
   end
 
-  scope :bastion, :module => :bastion do
+  scope :module => :bastion do
 
-    match '/:bastion_page/(*path)', :to => "bastion#index", constraints: BastionPagesConstraint.new
-    match '/bastion/(*path)', :to => "bastion#index_ie"
+    get '/:bastion_page/(*path)', :to => "bastion#index", constraints: BastionPagesConstraint.new
+    get '/bastion/(*path)', :to => "bastion#index_ie"
 
   end
 


### PR DESCRIPTION
I was getting route not found errors on all the katello pages in rails 4, when I checked routes, I was seeing ```bastion/:bastion_page``` instead of ```/:bastion_page```