### PR TITLE
Fixes #13108 -  Add assets to precompile in engine

### DIFF
--- a/lib/bastion/engine.rb
+++ b/lib/bastion/engine.rb
@@ -14,7 +14,7 @@ module Bastion
       app.routes_reloader.paths.unshift("#{Bastion::Engine.root}/config/routes.rb")
     end
 
-    initializer "bastion.plugin", :group => :all do |app|
+    initializer "bastion.configure_assets", :group => :all do |app|
       SETTINGS[:bastion] = {:assets => {}} if SETTINGS[:bastion].nil?
 
       SETTINGS[:bastion][:assets][:precompile] = [
@@ -28,6 +28,10 @@ module Bastion
       end
 
       SETTINGS[:bastion][:assets][:precompile].concat(locale_files)
+    end
+
+    initializer 'bastion.assets.precompile', :after => 'bastion.configure_assets' do |app|
+      app.config.assets.precompile += SETTINGS[:bastion][:assets][:precompile]
     end
 
     initializer "angular_templates", :group => :all do |app|


### PR DESCRIPTION
To avoid the option development.rb config.assets.raise_runtime_errors
raise errors on Katello because the bastion assets are not loaded,
foreman will have to find them and add them to assets.precompile.

In order for foreman to find the assets paths, the initializer that
contains this settings needs to be named configure_assets and return the
SETTINGS[:bastion] hash