### PR TITLE
Fixes #13116 - Add global notifications

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-global-notification.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-global-notification.directive.js
@@ -1,0 +1,21 @@
+/**
+ * @ngdoc directive
+ * @name Bastion.components.directive:bstGlobalNotification
+ *
+ * @requires $scope
+ * @requires GlobalNotification
+ *
+ * @description
+ *   Provides a way to display global notifications
+ */
+
+angular.module("Bastion.components").directive('bstGlobalNotification', function () {
+    return {
+        templateUrl: 'components/views/bst-global-notification.html',
+        scope: {},
+        controller: ['$scope', 'GlobalNotification', function ($scope, GlobalNotification) {
+            $scope.successMessages = GlobalNotification.successMessages;
+            $scope.errorMessages = GlobalNotification.errorMessages;
+        }]
+    };
+});

--- a/app/assets/javascripts/bastion/components/global-notification.service.js
+++ b/app/assets/javascripts/bastion/components/global-notification.service.js
@@ -1,0 +1,29 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.components.service:GlobalNotification
+ *
+ * @description
+ *  Service to display a global notifcation
+ */
+angular.module('Bastion.components').service("GlobalNotification", function () {
+    this.errorMessages = [];
+    this.successMessages = [];
+
+    this.setSuccessMessage = function (message) {
+        this.successMessages.push(message);
+    };
+
+    this.setErrorMessage = function (message) {
+        this.errorMessages.push(message);
+    };
+
+    this.setRenderedSuccessMessage = function (message) {
+        var messageObj = { "message": message, "render": true };
+        this.successMessages.push(messageObj);
+    };
+
+    this.setRenderedErrorMessage = function (message) {
+        var messageObj = { "message": message, "render": true };
+        this.errorMessages.push(messageObj);
+    };
+});

--- a/app/assets/javascripts/bastion/components/views/bst-alerts.html
+++ b/app/assets/javascripts/bastion/components/views/bst-alerts.html
@@ -1,6 +1,7 @@
 <div ng-repeat="type in types">
   <div bst-alert="{{type}}" ng-repeat="alert in alerts[type] track by $index" close="closeAlert(type, $index)">
-    {{ alert }}
+    <span ng-if="alert.render" ng-bind-html="alert.message"></span>
+    <span ng-if="!(alert.render)">{{ alert }}</span>
   </div>
 </div>
 

--- a/app/assets/javascripts/bastion/components/views/bst-global-notification.html
+++ b/app/assets/javascripts/bastion/components/views/bst-global-notification.html
@@ -1,0 +1,1 @@
+<div bst-alerts error-messages="errorMessages" success-messages="successMessages"></div>

--- a/app/assets/javascripts/bastion/layouts/nutupane.html
+++ b/app/assets/javascripts/bastion/layouts/nutupane.html
@@ -1,6 +1,6 @@
 <section>
 
-  <div data-block="messages" bst-alerts error-messages="errorMessages" success-messages="successMessages"></div>
+  <div bst-global-notification></div>
 
   <div class="row nutupane-bar">
     <h2 class="col-sm-2">

--- a/test/components/bst-alerts.directive.test.js
+++ b/test/components/bst-alerts.directive.test.js
@@ -4,7 +4,12 @@ describe('Directive: bstAlerts', function() {
         element,
         elementScope;
 
-    beforeEach(module('Bastion.components', 'components/views/bst-alerts.html', 'components/views/bst-alert.html'));
+    beforeEach(module(
+        'ngSanitize',
+        'Bastion.components', 
+        'components/views/bst-alerts.html', 
+        'components/views/bst-alert.html'
+    ));
 
     beforeEach(inject(function(_$compile_, _$rootScope_) {
         compile = _$compile_;

--- a/test/components/bst-global-notification.directive.test.js
+++ b/test/components/bst-global-notification.directive.test.js
@@ -1,0 +1,39 @@
+describe('Directive: bstGlobalNotification', function () {
+    var $scope, $compile, PageTitle;
+
+    beforeEach(module(
+        'ngSanitize',
+        'Bastion.components', 
+        'components/views/bst-global-notification.html',
+        'components/views/bst-alert.html', 
+        'components/views/bst-alerts.html'
+    ));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_, _GlobalNotification_) {
+        $compile = _$compile_;
+        $scope = _$rootScope_;
+        GlobalNotification = _GlobalNotification_;
+    }));
+
+    beforeEach(function () {
+        element = angular.element('<div bst-global-notification></div>');
+        $compile(element)($scope);
+        $scope.$digest();
+    });
+
+    it("should display an error message", function () {
+        errorMessage = "Something is wrong!!";
+        GlobalNotification.setErrorMessage(errorMessage);
+
+        $scope.$digest();
+        expect(element.html().indexOf(errorMessage)).toBeGreaterThan(0);
+    });
+
+    it("should display a success message", function () {
+        successMessage = "success!!";
+        GlobalNotification.setSuccessMessage(successMessage);
+
+        $scope.$digest();
+        expect(element.html().indexOf(successMessage)).toBeGreaterThan(0);
+    });
+});

--- a/test/components/global-notification.service.test.js
+++ b/test/components/global-notification.service.test.js
@@ -1,0 +1,35 @@
+describe('Factory: GlobalNofification', function() {
+    beforeEach(module('Bastion.components'));
+
+    beforeEach(inject(function (_GlobalNotification_) {
+        GlobalNotification = _GlobalNotification_;
+    }));
+
+   it("provides a way to set error messages", function () {
+        errorMessage = "Everything is broken!";
+        GlobalNotification.setErrorMessage(errorMessage);
+        expect(GlobalNotification.errorMessages.length).toBe(1);
+        expect(GlobalNotification.errorMessages[0]).toBe(errorMessage);
+    });
+
+    it("provides a way to set success messages", function () {
+        successMessage = "Everything ran correctly!";
+        GlobalNotification.setSuccessMessage(successMessage);
+        expect(GlobalNotification.successMessages.length).toBe(1);
+        expect(GlobalNotification.successMessages[0]).toBe(successMessage);
+    });
+
+    it("provides a way to set rendered error messages", function () {
+        errorMessage = "Everything is broken!";
+        GlobalNotification.setRenderedErrorMessage(errorMessage);
+        expect(GlobalNotification.errorMessages.length).toBe(1);
+        expect(GlobalNotification.errorMessages[0]['message']).toBe(errorMessage);
+    });
+
+    it("provides a way to set rendered success messages", function () {
+        successMessage = "Everything ran correctly!";
+        GlobalNotification.setRenderedSuccessMessage(successMessage);
+        expect(GlobalNotification.successMessages.length).toBe(1);
+        expect(GlobalNotification.successMessages[0]['message']).toBe(successMessage);
+    })
+});


### PR DESCRIPTION
This adds global notifications, I will open a separate PR that converts Katello to use global notifications, as this breaks functionality in Katello.