### PR TITLE
Fixes #13176 - Missing red x on error message

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-alert.html
+++ b/app/assets/javascripts/bastion/components/views/bst-alert.html
@@ -3,11 +3,9 @@
     <span class="pficon pficon-close"></span>
   </button>
   <span class="pficon-layered">
-      <span ng-show="type === 'danger'" class="pficon pficon-error-octagon"></span>
-      <span ng-show="type === 'danger'" class="pficon pficon-error-exclamation"></span>
+      <span ng-show="type === 'danger'" class="pficon pficon-error-circle-o"></span>
 
-      <span ng-show="type === 'warning'" class="pficon pficon-warning-triangle"></span>
-      <span ng-show="type === 'warning'" class="pficon pficon-warning-exclamation"></span>
+      <span ng-show="type === 'warning'" class="pficon pficon-warning-circle-o"></span>
 
       <span ng-show="type === 'info'" class="pficon pficon-info"></span>
 

--- a/app/assets/stylesheets/bastion/overrides.scss
+++ b/app/assets/stylesheets/bastion/overrides.scss
@@ -15,6 +15,10 @@
   p {
     margin-bottom: 0;
   }
+
+  div {
+    display: inline;
+  }
 }
 
 // Patternfly Overrides


### PR DESCRIPTION
It looks like the patternfly icons have changed their [names](https://www.patternfly.org/styles/icons/)

This also fixes the message and icon not being inline.