### PR TITLE
Fixes #14149: use padding when determining container scroll height.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
@@ -18,18 +18,26 @@
 angular.module('Bastion.components').directive('bstContainerScroll', ['$window', '$timeout', function ($window, $timeout) {
     return {
         restrict: 'A',
-
         compile: function (tElement) {
             tElement.addClass("container-scroll-wrapper");
+
             return function (scope, element) {
-                var windowElement = angular.element($window);
-                var addScroll = function () {
+                var windowElement = angular.element($window),
+                    bottomPadding = parseInt(element.css('padding-bottom').replace('px', ''), 10),
+                    addScroll;
+
+                addScroll = function () {
                     var windowHeight = windowElement.height(),
                         offset = element.offset().top;
+
+                    if (bottomPadding) {
+                        offset = offset + bottomPadding;
+                    }
 
                     element.outerHeight(windowHeight - offset);
                     element.height(windowHeight - offset);
                 };
+
                 windowElement.bind('resize', addScroll);
                 $timeout(function () {
                     windowElement.trigger('resize');

--- a/test/components/bst-container-scroll.directive.test.js
+++ b/test/components/bst-container-scroll.directive.test.js
@@ -1,15 +1,15 @@
 describe('Directive: bstContainerScroll', function() {
     var scope,
         compile,
-        window,
+        windowElement,
         tableElement;
 
     beforeEach(module('Bastion.components'));
 
-    beforeEach(inject(function(_$compile_, _$rootScope_, _$window_) {
+    beforeEach(inject(function(_$compile_, _$rootScope_, $window) {
         compile = _$compile_;
         scope = _$rootScope_;
-        window = _$window_;
+        windowElement = angular.element($window)
     }));
 
     beforeEach(function() {
@@ -32,12 +32,21 @@ describe('Directive: bstContainerScroll', function() {
     });
 
     it("should adjust the table height on window resize", function() {
-        var table = tableElement.find('table'),
-            windowElement = angular.element(window);
-
         windowElement.height('100px');
         windowElement.trigger('resize');
 
         expect(tableElement.height()).toEqual(windowElement.height() - tableElement.offset().top);
+    });
+
+    it("should add the nutupane details padding if it exists", function () {
+        tableElement.css('padding-bottom', '10px');
+
+        compile(tableElement)(scope);
+        scope.$digest();
+
+        windowElement.height('100px');
+        windowElement.trigger('resize');
+
+        expect(tableElement.height()).toEqual(windowElement.height() - (tableElement.offset().top + 10));
     });
 });


### PR DESCRIPTION
The container scroll directive was not taking padding height into
account when determining the height of the container.  This commit
fixes that issue.

http://projects.theforeman.org/issues/14149