### PR TITLE
Fixes #14165: fix typo on feature flag $inject.

### DIFF
--- a/app/assets/javascripts/bastion/features/bst-feature-flag.directive.js
+++ b/app/assets/javascripts/bastion/features/bst-feature-flag.directive.js
@@ -42,6 +42,6 @@
         .module('Bastion.features')
         .directive('bstFeatureFlag', bstFeatureFlag);
 
-    bstFeatureFlag.$injector = ['ngIfDirective', 'FeatureFlag'];
+    bstFeatureFlag.$inject = ['ngIfDirective', 'FeatureFlag'];
 
 })();


### PR DESCRIPTION
To inject dependencies this way it should be "$inject" instead of
"$injector".

http://projects.theforeman.org/issues/14165