### PR TITLE
Fixes #14243: don't encode '+' in query strings.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -58,8 +58,16 @@ angular.module('Bastion').config(
         });
 
         $urlRouterProvider.otherwise(function ($injector, $location) {
-            var $window = $injector.get('$window');
-            $window.location.href = $location.absUrl().replace(oldBrowserBastionPath, '');
+            var $window = $injector.get('$window'),
+                url = $location.absUrl();
+
+            // ensure we don't double encode +s
+            url = url.replace(/%2B/g, "+");
+
+            // Remove the old browser path if present
+            url = url.replace(oldBrowserBastionPath, '');
+
+            $window.location.href = url;
         });
 
         $locationProvider.html5Mode(true);


### PR DESCRIPTION
$location double encodes links that are already encoded resulting
in double encoding of +s (which are valid in query strings as
spaces).  This commit prevents the double encoding of +s.

http://projects.theforeman.org/issues/14243