### PR TITLE
Fixes #14524 - bst-table-column without value reverses column values

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -346,9 +346,10 @@ angular.module('Bastion.components').factory('Nutupane',
                 if (!column) {
                     return;
                 }
-
-                params["sort_by"] = column.id;
-                if (column.id === sort.by) {
+                if (column.id) {
+                    params["sort_by"] = column.id;
+                }
+                if (column.id === sort.by || column.id) {
                     params["sort_order"] = (sort.order === 'ASC') ? 'DESC' : 'ASC';
                 } else {
                     params["sort_order"] = 'ASC';


### PR DESCRIPTION
We may not want to `sort_by` a value when it comes from associated models. If `bst-table-column` is also `sortable`,  it reverses order of items by default.