### PR TITLE
Fixes #14578: ensure container scroll element is of a usable size.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-container-scroll.directive.js
@@ -24,7 +24,7 @@ angular.module('Bastion.components').directive('bstContainerScroll', ['$window',
             return function (scope, element) {
                 var windowElement = angular.element($window),
                     bottomPadding = parseInt(element.css('padding-bottom').replace('px', ''), 10),
-                    addScroll;
+                    newElementHeight, addScroll;
 
                 addScroll = function () {
                     var windowHeight = windowElement.height(),
@@ -34,8 +34,14 @@ angular.module('Bastion.components').directive('bstContainerScroll', ['$window',
                         offset = offset + bottomPadding;
                     }
 
-                    element.outerHeight(windowHeight - offset);
-                    element.height(windowHeight - offset);
+                    newElementHeight = windowHeight - offset;
+
+                    if (newElementHeight <= 100) {
+                        newElementHeight = 300;
+                    }
+
+                    element.outerHeight(newElementHeight);
+                    element.height(newElementHeight);
                 };
 
                 windowElement.bind('resize', addScroll);

--- a/test/components/bst-container-scroll.directive.test.js
+++ b/test/components/bst-container-scroll.directive.test.js
@@ -38,6 +38,17 @@ describe('Directive: bstContainerScroll', function() {
         expect(tableElement.height()).toEqual(windowElement.height() - tableElement.offset().top);
     });
 
+    it("should ensure that the element is at least 200px", function () {
+        windowElement.height('200px');
+        tableElement.css('padding-bottom', '200px');
+
+        compile(tableElement)(scope);
+        scope.$digest();
+
+        windowElement.trigger('resize');
+        expect(tableElement.height()).toEqual(300);
+    });
+
     it("should add the nutupane details padding if it exists", function () {
         tableElement.css('padding-bottom', '10px');
 


### PR DESCRIPTION
Fixing the container scroll directive by adding additional height
when the element appears further down the page.

http://projects.theforeman.org/issues/14578