### PR TITLE
Fixes #14904: ensure black text for bst-edit inside of rows.

### DIFF
--- a/app/assets/stylesheets/bastion/nutupane.scss
+++ b/app/assets/stylesheets/bastion/nutupane.scss
@@ -64,6 +64,10 @@ td.row-select {
       a {
         color: #FFF;
       }
+
+      .bst-edit:hover {
+        color: #000;
+      }
     }
 
     th.sortable {


### PR DESCRIPTION
Ensure the color of the text in a bst-edit element within a
highlighted row is black.

http://projects.theforeman.org/issues/14904