### PR TITLE
Fixes #15027: maintain number of selected rows between states.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-table.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-table.directive.js
@@ -44,7 +44,10 @@ angular.module('Bastion.components')
 
         this.selection = {allSelected: false, selectAllDisabled: false};
 
-        $scope.table.numSelected = 0;
+        if (!$scope.table.numSelected) {
+            $scope.table.numSelected = 0;
+        }
+
         $scope.table.chosenRow = null;
 
         $scope.table.getSelected = function () {


### PR DESCRIPTION
If rows have already been selected we should maintain the count of rows
between states.  This problem is commonly seen in the details-nutupane
tables.

http://projects.theforeman.org/issues/15027