### PR TITLE
Fixes #15352: redirect to a 404 page if state does not exist.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -59,6 +59,8 @@ angular.module('Bastion').config(
 
         $urlRouterProvider.otherwise(function ($injector, $location) {
             var $window = $injector.get('$window'),
+                $state = $injector.get('$state'),
+                parentState = $location.path().split('/')[1].replace('_', '-'),
                 url = $location.absUrl();
 
             // ensure we don't double encode +s
@@ -67,7 +69,12 @@ angular.module('Bastion').config(
             // Remove the old browser path if present
             url = url.replace(oldBrowserBastionPath, '');
 
-            $window.location.href = url;
+            if ($state.get(parentState)) {
+                $window.location.href = '/404';
+            } else {
+                $window.location.href = url;
+            }
+            return $location.path();
         });
 
         $locationProvider.html5Mode(true);


### PR DESCRIPTION
We were infinitely redirecting on sub-states that didn't exist.  This
commit redirects to a 404 page if a child state is not found.

http://projects.theforeman.org/issues/15352