### PR TITLE
Fixes #15544: show a loading screen while resource is loading.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/panel.html
+++ b/app/assets/javascripts/bastion/layouts/panel.html
@@ -1,0 +1,5 @@
+<div class="loading-mask loading-mask-panel fa-3x" ng-show="panel.loading">
+  <i class="fa fa-spinner fa-spin"></i>
+  {{ "Loading..." | translate }}
+</div>
+<span ng-hide="panel.loading" data-block="panel"></span>


### PR DESCRIPTION
Add support for a loading screen into the nutupane layout so that
a loading screen can be shown while the resource is loading.

http://projects.theforeman.org/issues/15544