### PR TITLE
Fixes #16031: Pin phantomjs-prebuilt to 2.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "karma-jasmine": "^1.0.2",
     "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
-    "require-dir": "~0.1.0"
+    "require-dir": "~0.1.0",
+    "phantomjs-prebuilt": "2.1.10"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
This fixes an issue with npm install breaking unable to find
throttleit.