### PR TITLE
Fixes #16296 - Pass content to errorCatcher

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "angular-i18n": "1.3.13",
     "underscore": "=1.5.2",
     "ngInfiniteScroll": "1.2.1",
-    "ngUpload": "~0.5.5",
+    "ngUpload": "0.5.18",
     "angular-animate": "=1.5.5",
     "angular-uuid4": "0.1.0"
   },

--- a/vendor/assets/javascripts/bastion/ngUpload/ng-upload.js
+++ b/vendor/assets/javascripts/bastion/ngUpload/ng-upload.js
@@ -214,10 +214,10 @@ angular.module('ngUpload', [])
                 if ( errorCatcher ){
                    if (!scope.$$phase) {
                       scope.$apply(function () {
-                          errorCatcher(scope, { error: error});
+                          errorCatcher(scope, { error: error, content: content});
                       });
                    } else {
-                     errorCatcher(scope, { error: error});
+                     errorCatcher(scope, { error: error, content: content});
                    }
                 }
 


### PR DESCRIPTION
This is a temporary fix to our local copy of ng-upload until https://github.com/twilson63/ngUpload/pull/133 is merged.