### PR TITLE
Fixes #16297: Don't require base for HTML5 mode

### DIFF
--- a/app/assets/javascripts/bastion/routing.module.js
+++ b/app/assets/javascripts/bastion/routing.module.js
@@ -72,7 +72,7 @@ angular.module('Bastion.routing', ['ui.router']);
             return $location.path();
         });
 
-        $locationProvider.html5Mode(true);
+        $locationProvider.html5Mode({enabled: true, requireBase: false});
 
     }
 

--- a/app/views/bastion/layouts/application.html.erb
+++ b/app/views/bastion/layouts/application.html.erb
@@ -1,7 +1,3 @@
-<% content_for(:head) do %>
-    <base href="/bastion"/>
-<% end %>
-
 <% content_for(:content) do %>
   <div class="article maincontent bastion" data-no-turbolink="true">
     <section class="container-fluid">

--- a/app/views/bastion/layouts/application_ie.html.erb
+++ b/app/views/bastion/layouts/application_ie.html.erb
@@ -1,5 +1,1 @@
-<% content_for(:head) do %>
-  <base href="/bastion"/>
-<% end %>
-
 <%= render file: "bastion/layouts/application" %>


### PR DESCRIPTION
This base requirement leads to test failures and errors in plugins
and modules inheriting.