### PR TITLE
Fixes #16534: add "non-nutupane" alternative. 

### DIFF
--- a/app/assets/javascripts/bastion/bastion.js
+++ b/app/assets/javascripts/bastion/bastion.js
@@ -9,6 +9,7 @@
 //= require "bastion/ngInfiniteScroll/ng-infinite-scroll.js"
 //= require "bastion/angular-gettext/angular-gettext"
 //= require "bastion/angular-blocks/angular-blocks"
+//= require "bastion/angular-breadcrumb/angular-breadcrumb"
 //= require_tree "../../../../vendor/assets/javascripts/bastion/angular-bootstrap"
 //= require "bastion/angular-animate/angular-animate"
 //= require "angular-rails-templates"

--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -6,7 +6,7 @@
  *   Base module that defines the Katello module namespace and includes any thirdparty
  *   modules used by the application.
  */
-angular.module('Bastion', []);
+angular.module('Bastion', ['ncy-angular-breadcrumb']);
 
 /**
  * @ngdoc config

--- a/app/assets/javascripts/bastion/components/bst-edit.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-edit.directive.js
@@ -16,7 +16,6 @@
 angular.module('Bastion.components')
     .directive('bstEdit', function () {
         return {
-            replace: true,
             controller: 'BstEditController',
             templateUrl: 'components/views/bst-edit.html'
         };
@@ -169,7 +168,6 @@ angular.module('Bastion.components')
     }])
     .directive('bstEditText', function () {
         return {
-            replace: true,
             scope: {
                 model: '=bstEditText',
                 readonly: '=',
@@ -183,7 +181,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditTextarea', function () {
         return {
-            replace: true,
             scope: {
                 model: '=bstEditTextarea',
                 readonly: '=',
@@ -195,7 +192,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditNumber', function () {
         return {
-            replace: true,
             scope: {
                 model: '=bstEditNumber',
                 readonly: '=',
@@ -211,7 +207,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditCheckbox', function () {
         return {
-            replace: true,
             scope: {
                 model: '=bstEditCheckbox',
                 readonly: '=',
@@ -225,7 +220,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditCustom', function () {
         return {
-            replace: true,
             transclude: true,
             templateUrl: 'components/views/bst-edit-custom.html',
             scope: {
@@ -242,7 +236,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditSelect', function () {
         return {
-            replace: true,
             scope: {
                 model: '=bstEditSelect',
                 displayValueDefault: '=displayValueDefault',
@@ -267,7 +260,6 @@ angular.module('Bastion.components')
     })
     .directive('bstEditMultiselect', function () {
         return {
-            replace: true,
             templateUrl: 'components/views/bst-edit-multiselect.html',
             scope: {
                 model: '=bstEditMultiselect',

--- a/app/assets/javascripts/bastion/components/bst-table.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-table.directive.js
@@ -139,7 +139,7 @@ angular.module('Bastion.components')
                 }
 
                 return function (scope, element, attrs, bstTableController) {
-                    if (angular.isDefined(tAttrs.rowSelect)) {
+                    if (angular.isDefined(tAttrs.rowSelect) && angular.isDefined(scope.table)) {
                         scope.table.rowSelect = true;
                     } else if (angular.isDefined(tAttrs.rowChoice)) {
                         scope.table.rowChoice = true;

--- a/app/assets/javascripts/bastion/components/views/bst-edit.html
+++ b/app/assets/javascripts/bastion/components/views/bst-edit.html
@@ -1,8 +1,8 @@
 <div class="bst-edit">
   <div class="value" ng-class="{ 'editable' : !readonly }" ng-click="edit()" ng-hide="editMode || workingMode">
-    <span class="fr">
-      <i class="fa fa-edit inline-icon" ng-hide="editMode || readonly"></i>
-      <i class="fa fa-remove inline-icon" ng-click="delete($event)" ng-show="deletable && !editMode && !readonly"></i>
+    <span class="fr" ng-hide="editMode || readonly">
+      <i class="fa fa-edit inline-icon"></i>
+      <i class="fa fa-remove inline-icon" ng-click="delete($event)" ng-show="deletable"></i>
     </span>
     <span class="editable-value">{{ displayValue }}</span>
   </div>

--- a/app/assets/javascripts/bastion/layouts/page-with-breadcrumbs.html
+++ b/app/assets/javascripts/bastion/layouts/page-with-breadcrumbs.html
@@ -1,0 +1,28 @@
+<div class="loading-mask fa-3x" ng-show="page.loading">
+  <i class="fa fa-spinner fa-spin"></i>
+  {{ "Loading..." | translate }}
+</div>
+
+<div class="row header-bar">
+  <div class="col-sm-10">
+    <span data-block="header"></span>
+  </div>
+
+  <div class="fr">
+    <span data-block="item-actions"></span>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <div ncy-breadcrumb></div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <div ng-hide="page && (page.loading || page.error)">
+      <span data-block="content"></span>
+    </div>
+  </div>
+</div>

--- a/app/assets/javascripts/bastion/layouts/table.html
+++ b/app/assets/javascripts/bastion/layouts/table.html
@@ -1,0 +1,94 @@
+<section>
+
+  <div bst-global-notification></div>
+
+  <div class="row header-bar">
+    <h2 class="col-sm-10">
+      <span data-block="header">
+        REPLACE ME
+      </span>
+    </h2>
+    <div class="fr">
+      <span data-block="item-actions"></span>
+    </div>
+  </div>
+
+  <div class="row header-bar">
+    <div class="row">
+      <div class="col-sm-12">
+        <div data-block="search-filter"></div>
+      </div>
+    </div>
+
+    <div class="col-sm-3">
+      <div class="input-group input-group">
+        <input type="text"
+               class="form-control"
+               placeholder="{{ 'Filter...' | translate }}"
+               bst-on-enter="table.search(table.searchTerm)"
+               ng-model="table.searchTerm"
+               ng-trim="false"
+               typeahead="item.label for item in table.autocomplete($viewValue)"
+               typeahead-empty
+               typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
+        <span class="input-group-btn">
+          <button class="btn btn-default"
+                  type="button"
+                  ng-click='table.search("") && (table.searchCompleted = false)' 
+                  ng-show="table.searchCompleted && table.searchTerm">
+            <i class="fa fa-times"></i>
+          </button>
+          <button ng-click="table.search(table.searchTerm)" class="btn btn-default" type="button">
+            <i class="fa fa-search"></i>
+            <span translate>Search</span>
+          </button>
+          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+            <i class="fa fa-caret-down"></i>
+          </button>
+          <ul bst-bookmark controller-name="controllerName" query="table.searchTerm" class="dropdown-menu pull-right"></ul>
+        </span>
+      </div>
+    </div>
+
+    <div class="col-sm-3">
+      <span translate>Showing {{ table.rows.length }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total)</span>
+    </div>
+
+    <div class="fr">
+      <div class="fl">
+        <div data-block="list-actions"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row header-bar">
+    <div class="fr">
+      <span translate>{{ table.numSelected }} Selected</span>
+    </div>
+    <div class="col-sm-5">
+      <span data-block="filters"></span>
+    </div>
+  </div>
+
+  <div class="row nutupane" bst-table="table" nutupane-table>
+    <div class="loading-mask" ng-show="table.refreshing" >
+      <i class="fa fa-spinner fa-spin"></i>
+      <span>{{ "Loading..." | translate }}</span>
+    </div>
+
+    <p bst-alert="info" ng-show="table.rows.length === 0 && !table.working && !table.searchTerm && !table.searchCompleted">
+      <span data-block="no-rows-message"></span>
+    </p>
+    <p bst-alert="info" ng-show="table.rows.length === 0 && !table.working && (table.searchTerm || table.searchCompleted)">
+      <span data-block="no-search-results-message"></span>
+    </p>
+
+    <div ng-show="table.rows.length > 0" bst-container-scroll data="table.rows">
+      <div infinite-scroll="table.nextPage()" infinite-scroll-container="'.container-scroll-wrapper'"
+           infinite-scroll-listen-for-event="nutupane:loaded">
+        <div data-block="table"></div>
+      </div>
+    </div>
+  </div>
+
+</section>

--- a/app/assets/javascripts/bastion/layouts/two-column.html
+++ b/app/assets/javascripts/bastion/layouts/two-column.html
@@ -1,0 +1,10 @@
+<div class="row">
+  <section class="col-sm-5">
+    <div data-block="left-column"></div>
+  </section>
+
+  <section class="col-sm-5 col-sm-offset-1">
+    <div data-block="right-column"></div>
+  </section>
+</div>
+

--- a/app/assets/stylesheets/bastion/bastion.scss
+++ b/app/assets/stylesheets/bastion/bastion.scss
@@ -7,6 +7,7 @@
   @import "mixins";
   @import "variables";
   @import "nutupane";
+  @import "components";
   @import "overrides";
   @import "helpers";
   @import "./forms";
@@ -18,13 +19,6 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
-  }
-
-  .container-fluid {
-    margin-right: auto;
-    margin-left: auto;
-    padding-left: 15px;
-    padding-right: 15px;
   }
 
   a {

--- a/app/assets/stylesheets/bastion/components.scss
+++ b/app/assets/stylesheets/bastion/components.scss
@@ -1,0 +1,28 @@
+.header-bar {
+  background: rgb(250, 250, 250);
+  padding: 10px 15px 10px 0;
+  border-bottom: 1px solid rgb(230, 230, 230);
+
+  h2 {
+    margin: 5px 0 0 0;
+  }
+}
+
+.dl-horizontal.dl-horizontal-left {
+  dt {
+    overflow: visible;
+    text-align: left;
+    text-overflow: clip;
+    white-space: pre-wrap;
+    width: 125px;
+  }
+
+  dt:after {
+    content: ':';
+  }
+
+  dd {
+    margin-left: 200px;
+    word-wrap: break-word;
+  }
+}

--- a/app/assets/stylesheets/bastion/forms.scss
+++ b/app/assets/stylesheets/bastion/forms.scss
@@ -37,5 +37,5 @@
 }
 
 .editable-value {
-  white-space: pre;
+  white-space: pre-line;
 }

--- a/app/assets/stylesheets/bastion/overrides.scss
+++ b/app/assets/stylesheets/bastion/overrides.scss
@@ -56,6 +56,7 @@ ul {
   }
 }
 
-.row {
-  margin-right: -7px;
+.dropdown-menu li .disabled {
+  @extend .text-muted;
+  padding: 1px 10px;
 }

--- a/app/assets/stylesheets/bastion/typography.scss
+++ b/app/assets/stylesheets/bastion/typography.scss
@@ -33,3 +33,4 @@ pre {
 .alert {
   word-wrap: break-word;
 }
+

--- a/app/views/bastion/layouts/application.html.erb
+++ b/app/views/bastion/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:content) do %>
   <div class="article maincontent bastion" data-no-turbolink="true">
     <section class="container-fluid">
-        <div class="row" ui-view></div>
+        <div ui-view></div>
     </section>
   </div>
 <% end %>

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "es5-shim": "~2.0.8",
     "angular": "=1.5.5",
     "angular-bootstrap": "0.10.0",
-    "angular": "=1.5.5",
+    "angular-breadcrumb": "=0.4.1",
     "angular-sanitize": "=1.5.5",
     "angular-resource": "=1.5.5",
     "angular-route": "=1.5.5",
@@ -60,6 +60,9 @@
         "ui-bootstrap.js",
         "ui-bootstrap-tpls.js"
       ]
+    },
+    "angular-breadcrumb": {
+      "javascripts/bastion/angular-breadcrumb": "dist/angular-breadcrumb.js"
     },
     "angular-animate": {
       "javascripts/bastion/angular-animate": "angular-animate.js"

--- a/vendor/assets/javascripts/bastion/angular-breadcrumb/angular-breadcrumb.js
+++ b/vendor/assets/javascripts/bastion/angular-breadcrumb/angular-breadcrumb.js
@@ -1,0 +1,369 @@
+/*! angular-breadcrumb - v0.4.0-dev-2015-08-07
+* http://ncuillery.github.io/angular-breadcrumb
+* Copyright (c) 2015 Nicolas Cuillery; Licensed MIT */
+
+(function (window, angular, undefined) {
+'use strict';
+
+function isAOlderThanB(scopeA, scopeB) {
+    if(angular.equals(scopeA.length, scopeB.length)) {
+        return scopeA > scopeB;
+    } else {
+        return scopeA.length > scopeB.length;
+    }
+}
+
+function parseStateRef(ref) {
+    var parsed = ref.replace(/\n/g, " ").match(/^([^(]+?)\s*(\((.*)\))?$/);
+    if (!parsed || parsed.length !== 4) { throw new Error("Invalid state ref '" + ref + "'"); }
+    return { state: parsed[1], paramExpr: parsed[3] || null };
+}
+
+function $Breadcrumb() {
+
+    var $$options = {
+        prefixStateName: null,
+        template: 'bootstrap3',
+        templateUrl: null,
+        includeAbstract : false
+    };
+
+    this.setOptions = function(options) {
+        angular.extend($$options, options);
+    };
+
+    this.$get = ['$state', '$stateParams', '$rootScope', function($state, $stateParams, $rootScope) {
+
+        var $lastViewScope = $rootScope;
+
+        // Early catch of $viewContentLoaded event
+        $rootScope.$on('$viewContentLoaded', function (event) {
+            // With nested views, the event occur several times, in "wrong" order
+            if(!event.targetScope.ncyBreadcrumbIgnore &&
+                isAOlderThanB(event.targetScope.$id, $lastViewScope.$id)) {
+                $lastViewScope = event.targetScope;
+            }
+        });
+
+        // Get the parent state
+        var $$parentState = function(state) {
+            // Check if state has explicit parent OR we try guess parent from its name
+            var parent = state.parent || (/^(.+)\.[^.]+$/.exec(state.name) || [])[1];
+            var isObjectParent = typeof parent === "object";
+            // if parent is a object reference, then extract the name
+            return isObjectParent ? parent.name : parent;
+        };
+
+        // Add the state in the chain if not already in and if not abstract
+        var $$addStateInChain = function(chain, stateRef) {
+            var conf,
+                parentParams,
+                ref = parseStateRef(stateRef),
+                force = false,
+                skip = false;
+
+            for(var i=0, l=chain.length; i<l; i+=1) {
+                if (chain[i].name === ref.state) {
+                    return;
+                }
+            }
+
+            conf = $state.get(ref.state);
+            // Get breadcrumb options
+            if(conf.ncyBreadcrumb) {
+                if(conf.ncyBreadcrumb.force){ force = true; }
+                if(conf.ncyBreadcrumb.skip){ skip = true; }
+            }
+            if((!conf.abstract || $$options.includeAbstract || force) && !skip) {
+                if(ref.paramExpr) {
+                    parentParams = $lastViewScope.$eval(ref.paramExpr);
+                }
+
+                conf.ncyBreadcrumbLink = $state.href(ref.state, parentParams || $stateParams || {});
+                chain.unshift(conf);
+            }
+        };
+
+        // Get the state for the parent step in the breadcrumb
+        var $$breadcrumbParentState = function(stateRef) {
+            var ref = parseStateRef(stateRef),
+                conf = $state.get(ref.state);
+
+            if(conf.ncyBreadcrumb && conf.ncyBreadcrumb.parent) {
+                // Handle the "parent" property of the breadcrumb, override the parent/child relation of the state
+                var isFunction = typeof conf.ncyBreadcrumb.parent === 'function';
+                var parentStateRef = isFunction ? conf.ncyBreadcrumb.parent($lastViewScope) : conf.ncyBreadcrumb.parent;
+                if(parentStateRef) {
+                    return parentStateRef;
+                }
+            }
+
+            return $$parentState(conf);
+        };
+
+        return {
+
+            getTemplate: function(templates) {
+                if($$options.templateUrl) {
+                    // templateUrl takes precedence over template
+                    return null;
+                } else if(templates[$$options.template]) {
+                    // Predefined templates (bootstrap, ...)
+                    return templates[$$options.template];
+                } else {
+                    return $$options.template;
+                }
+            },
+
+            getTemplateUrl: function() {
+                return $$options.templateUrl;
+            },
+
+            getStatesChain: function(exitOnFirst) { // Deliberately undocumented param, see getLastStep
+                var chain = [];
+
+                // From current state to the root
+                for(var stateRef = $state.$current.self.name; stateRef; stateRef=$$breadcrumbParentState(stateRef)) {
+                    $$addStateInChain(chain, stateRef);
+                    if(exitOnFirst && chain.length) {
+                        return chain;
+                    }
+                }
+
+                // Prefix state treatment
+                if($$options.prefixStateName) {
+                    $$addStateInChain(chain, $$options.prefixStateName);
+                }
+
+                return chain;
+            },
+
+            getLastStep: function() {
+                var chain = this.getStatesChain(true);
+                return chain.length ? chain[0] : undefined;
+            },
+
+            $getLastViewScope: function() {
+                return $lastViewScope;
+            }
+        };
+    }];
+}
+
+var getExpression = function(interpolationFunction) {
+    if(interpolationFunction.expressions) {
+        return interpolationFunction.expressions;
+    } else {
+        var expressions = [];
+        angular.forEach(interpolationFunction.parts, function(part) {
+            if(angular.isFunction(part)) {
+                expressions.push(part.exp);
+            }
+        });
+        return expressions;
+    }
+};
+
+var registerWatchers = function(labelWatcherArray, interpolationFunction, viewScope, step) {
+    angular.forEach(getExpression(interpolationFunction), function(expression) {
+        var watcher = viewScope.$watch(expression, function() {
+            step.ncyBreadcrumbLabel = interpolationFunction(viewScope);
+        });
+        labelWatcherArray.push(watcher);
+    });
+
+};
+
+var deregisterWatchers = function(labelWatcherArray) {
+    angular.forEach(labelWatcherArray, function(deregisterWatch) {
+        deregisterWatch();
+    });
+};
+
+function BreadcrumbDirective($interpolate, $breadcrumb, $rootScope) {
+    var $$templates = {
+        bootstrap2: '<ul class="breadcrumb">' +
+            '<li ng-repeat="step in steps" ng-switch="$last || !!step.abstract" ng-class="{active: $last}">' +
+            '<a ng-switch-when="false" href="{{step.ncyBreadcrumbLink}}">{{step.ncyBreadcrumbLabel}}</a>' +
+            '<span ng-switch-when="true">{{step.ncyBreadcrumbLabel}}</span>' +
+            '<span class="divider" ng-hide="$last">/</span>' +
+            '</li>' +
+            '</ul>',
+        bootstrap3: '<ol class="breadcrumb">' +
+            '<li ng-repeat="step in steps" ng-class="{active: $last}" ng-switch="$last || !!step.abstract">' +
+            '<a ng-switch-when="false" href="{{step.ncyBreadcrumbLink}}">{{step.ncyBreadcrumbLabel}}</a>' +
+            '<span ng-switch-when="true">{{step.ncyBreadcrumbLabel}}</span>' +
+            '</li>' +
+            '</ol>'
+    };
+
+    return {
+        restrict: 'AE',
+        replace: true,
+        scope: {},
+        template: $breadcrumb.getTemplate($$templates),
+        templateUrl: $breadcrumb.getTemplateUrl(),
+        link: {
+            post: function postLink(scope) {
+                var labelWatchers = [];
+
+                var renderBreadcrumb = function() {
+                    deregisterWatchers(labelWatchers);
+                    labelWatchers = [];
+                    
+                    var viewScope = $breadcrumb.$getLastViewScope();
+                    scope.steps = $breadcrumb.getStatesChain();
+                    angular.forEach(scope.steps, function (step) {
+                        if (step.ncyBreadcrumb && step.ncyBreadcrumb.label) {
+                            var parseLabel = $interpolate(step.ncyBreadcrumb.label);
+                            step.ncyBreadcrumbLabel = parseLabel(viewScope);
+                            // Watcher for further viewScope updates
+                            registerWatchers(labelWatchers, parseLabel, viewScope, step);
+                        } else {
+                            step.ncyBreadcrumbLabel = step.name;
+                        }
+                    });
+                };
+
+                $rootScope.$on('$viewContentLoaded', function (event) {
+                    if(!event.targetScope.ncyBreadcrumbIgnore) {
+                        renderBreadcrumb();
+                    }
+                });
+
+                // View(s) may be already loaded while the directive's linking
+                renderBreadcrumb();
+            }
+        }
+    };
+}
+BreadcrumbDirective.$inject = ['$interpolate', '$breadcrumb', '$rootScope'];
+
+function BreadcrumbLastDirective($interpolate, $breadcrumb, $rootScope) {
+
+    return {
+        restrict: 'A',
+        scope: {},
+        template: '{{ncyBreadcrumbLabel}}',
+        compile: function(cElement, cAttrs) {
+
+            // Override the default template if ncyBreadcrumbLast has a value
+            var template = cElement.attr(cAttrs.$attr.ncyBreadcrumbLast);
+            if(template) {
+                cElement.html(template);
+            }
+
+            return {
+                post: function postLink(scope) {
+                    var labelWatchers = [];
+
+                    var renderLabel = function() {
+                        deregisterWatchers(labelWatchers);
+                        labelWatchers = [];
+                        
+                        var viewScope = $breadcrumb.$getLastViewScope();
+                        var lastStep = $breadcrumb.getLastStep();
+                        if(lastStep) {
+                            scope.ncyBreadcrumbLink = lastStep.ncyBreadcrumbLink;
+                            if (lastStep.ncyBreadcrumb && lastStep.ncyBreadcrumb.label) {
+                                var parseLabel = $interpolate(lastStep.ncyBreadcrumb.label);
+                                scope.ncyBreadcrumbLabel = parseLabel(viewScope);
+                                // Watcher for further viewScope updates
+                                // Tricky last arg: the last step is the entire scope of the directive !
+                                registerWatchers(labelWatchers, parseLabel, viewScope, scope);
+                            } else {
+                                scope.ncyBreadcrumbLabel = lastStep.name;
+                            }
+                        }
+                    };
+
+                    $rootScope.$on('$viewContentLoaded', function (event) {
+                        if(!event.targetScope.ncyBreadcrumbIgnore) {
+                            renderLabel();
+                        }
+                    });
+
+                    // View(s) may be already loaded while the directive's linking
+                    renderLabel();
+                }
+            };
+
+        }
+    };
+}
+BreadcrumbLastDirective.$inject = ['$interpolate', '$breadcrumb', '$rootScope'];
+
+function BreadcrumbTextDirective($interpolate, $breadcrumb, $rootScope) {
+
+    return {
+        restrict: 'A',
+        scope: {},
+        template: '{{ncyBreadcrumbChain}}',
+
+        compile: function(cElement, cAttrs) {
+            // Override the default template if ncyBreadcrumbText has a value
+            var template = cElement.attr(cAttrs.$attr.ncyBreadcrumbText);
+            if(template) {
+                cElement.html(template);
+            }
+            
+            var separator = cElement.attr(cAttrs.$attr.ncyBreadcrumbTextSeparator) || ' / ';
+
+            return {
+                post: function postLink(scope) {
+                    var labelWatchers = [];
+                    
+                    var registerWatchersText = function(labelWatcherArray, interpolationFunction, viewScope) {
+                        angular.forEach(getExpression(interpolationFunction), function(expression) {
+                            var watcher = viewScope.$watch(expression, function(newValue, oldValue) {
+                                if (newValue !== oldValue) {
+                                    renderLabel();
+                                }
+                            });
+                            labelWatcherArray.push(watcher);
+                        });
+                    };
+
+                    var renderLabel = function() {
+                        deregisterWatchers(labelWatchers);
+                        labelWatchers = [];
+                        
+                        var viewScope = $breadcrumb.$getLastViewScope();
+                        var steps = $breadcrumb.getStatesChain();
+                        var combinedLabels = [];
+                        angular.forEach(steps, function (step) {
+                            if (step.ncyBreadcrumb && step.ncyBreadcrumb.label) {
+                                var parseLabel = $interpolate(step.ncyBreadcrumb.label);
+                                combinedLabels.push(parseLabel(viewScope));
+                                // Watcher for further viewScope updates
+                                registerWatchersText(labelWatchers, parseLabel, viewScope);
+                            } else {
+                                combinedLabels.push(step.name);
+                            }
+                        });
+                        
+                        scope.ncyBreadcrumbChain = combinedLabels.join(separator);
+                    };
+
+                    $rootScope.$on('$viewContentLoaded', function (event) {
+                        if(!event.targetScope.ncyBreadcrumbIgnore) {
+                            renderLabel();
+                        }
+                    });
+
+                    // View(s) may be already loaded while the directive's linking
+                    renderLabel();
+                }
+            };
+
+        }
+    };
+}
+BreadcrumbTextDirective.$inject = ['$interpolate', '$breadcrumb', '$rootScope'];
+
+angular.module('ncy-angular-breadcrumb', ['ui.router.state'])
+    .provider('$breadcrumb', $Breadcrumb)
+    .directive('ncyBreadcrumb', BreadcrumbDirective)
+    .directive('ncyBreadcrumbLast', BreadcrumbLastDirective)
+    .directive('ncyBreadcrumbText', BreadcrumbTextDirective);
+})(window, window.angular);


### PR DESCRIPTION
Adding an alternative full page layout to nutupane that uses the breadcrumbs
from the previous commit.  Also adds a two column layout using bootstrap
3's grid system to replace the float method currently used.

http://projects.theforeman.org/issues/16534


Here is a page that points out some of the problems with our current approach (at 1280x800px):

![screen shot 2016-09-13 at 12 05 25 pm](https://cloud.githubusercontent.com/assets/4116405/18481508/64ea552c-79aa-11e6-864b-d64ffed099f4.png)

On this page I am attempting to add an erratum to a filter in the table at the bottom.  Notice how small that table is and how much I would have to scroll if I had a lot of errata.  Also note the double scrollbars.