### PR TITLE
Fixes #16727: show 404 page within the application.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -83,6 +83,7 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
         $rootScope.$state = $state;
         $rootScope.$stateParams = $stateParams;
         $rootScope.transitionTo = $state.transitionTo;
+        $rootScope.$location = $location;
 
         $rootScope.isState = function (stateName) {
             return $state.is(stateName);

--- a/app/assets/javascripts/bastion/layouts/404.html
+++ b/app/assets/javascripts/bastion/layouts/404.html
@@ -1,0 +1,14 @@
+<span page-title>{{ '404 - Page Not Found' | translate }}</span>
+
+<section class="col-sm-12">
+  <h1 translate>404 - Page Not Found</h1>
+  <p translate>
+    The requested URL <strong>{{ $location.path() }}</strong> was not found.
+  </p>
+  <p translate>
+    You may have mistyped the address or the page may have moved.
+  </p>
+  <p translate>
+    If you are the application owner check the logs for more information.
+  </p>
+</section>

--- a/app/assets/javascripts/bastion/routing.module.js
+++ b/app/assets/javascripts/bastion/routing.module.js
@@ -13,7 +13,7 @@ angular.module('Bastion.routing', ['ui.router']);
      * @description
      *   Routing configuration for Bastion.
      */
-    function bastionRouting($urlRouterProvider, $locationProvider) {
+    function bastionRouting($stateProvider, $urlRouterProvider, $locationProvider) {
         var oldBrowserBastionPath = '/bastion#', getRootPath;
 
         getRootPath = function (path) {
@@ -24,6 +24,11 @@ angular.module('Bastion.routing', ['ui.router']);
             }
             return rootPath;
         };
+
+        $stateProvider.state('404', {
+            permission: null,
+            templateUrl: 'layouts/404.html'
+        });
 
         $urlRouterProvider.rule(function ($injector, $location) {
             var $sniffer = $injector.get('$sniffer'),
@@ -65,7 +70,7 @@ angular.module('Bastion.routing', ['ui.router']);
             }
 
             if (foundParentState) {
-                $window.location.href = '/404';
+                $state.go('404');
             } else {
                 $window.location.href = url;
             }
@@ -73,9 +78,8 @@ angular.module('Bastion.routing', ['ui.router']);
         });
 
         $locationProvider.html5Mode({enabled: true, requireBase: false});
-
     }
 
     angular.module('Bastion.routing').config(bastionRouting);
-    bastionRouting.$inject = ['$urlRouterProvider', '$locationProvider'];
+    bastionRouting.$inject = ['$stateProvider', '$urlRouterProvider', '$locationProvider'];
 })();

--- a/test/routing.module.test.js
+++ b/test/routing.module.test.js
@@ -6,7 +6,7 @@ describe('config: Bastion.routing', function () {
         $rootScope.$digest();
     }
 
-    beforeEach(module('Bastion.routing'));
+    beforeEach(module('Bastion.routing', 'layouts/404.html'));
 
     beforeEach(module(function ($provide) {
         $sniffer = {
@@ -56,8 +56,11 @@ describe('config: Bastion.routing', function () {
 
             it("redirecting to a 404 page if the parent state is found", function () {
                 spyOn($state, 'get').and.returnValue([{url: '/found-state'}]);
+                spyOn($state, 'go');
+
                 goTo('/found_state/does_not_exist');
-                expect($window.location.href).toBe('/404');
+
+                expect($state.go).toHaveBeenCalledWith('404');
             });
 
             it("redirecting to the url if no parent state is found", function () {


### PR DESCRIPTION
Rather than redirecting to a 404 page it is a better experience to show
the user the 404 page within the application so that they may see the
URL they are getting a 404 page on.  This commit does just that.

http://projects.theforeman.org/issues/16727