### PR TITLE
Fixes #15081: do not fade out success alert if it has focus.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-alert.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-alert.directive.js
@@ -24,13 +24,33 @@ angular.module('Bastion.components').directive('bstAlert', ['$animate', '$timeou
             close: '&'
         },
         link: function (scope, element, attrs) {
+            var fadeOutAnimation;
+
+            scope.fadePrevented = true;
             scope.closeable = 'close' in attrs;
 
-            // Fade out success alerts after five seconds
-            if (scope.type === 'success') {
+            scope.startFade = function () {
                 $timeout(function () {
-                    $animate.leave(element.find('.alert'), scope.close);
+                    if (!scope.fadePrevented) {
+                        fadeOutAnimation = $animate.leave(element.find('.alert'));
+                        fadeOutAnimation.then(function () {
+                            scope.close();
+                        });
+                    }
                 }, SUCCESS_FADEOUT);
+            };
+
+            scope.cancelFade = function () {
+                scope.fadePrevented = true;
+                if (fadeOutAnimation) {
+                    $animate.cancel(fadeOutAnimation);
+                }
+            };
+
+            // Automatically fade out success alerts
+            if (scope.type === 'success') {
+                scope.fadePrevented = false;
+                scope.startFade();
             }
         }
     };

--- a/app/assets/javascripts/bastion/components/views/bst-alert.html
+++ b/app/assets/javascripts/bastion/components/views/bst-alert.html
@@ -1,4 +1,4 @@
-<div class="alert" ng-class='"alert-" + (type || "warning")'>
+<div class="alert" ng-class='"alert-" + (type || "warning")' ng-mouseover="cancelFade()">
   <button ng-show="closeable" type="button" class="close" aria-hidden="true" ng-click="close()">
     <span class="pficon pficon-close"></span>
   </button>

--- a/test/components/bst-alert.directive.test.js
+++ b/test/components/bst-alert.directive.test.js
@@ -1,10 +1,41 @@
 describe('Directive: bstAlert', function() {
-    var scope,
-        compile,
-        element,
-        elementScope;
+    var $animate, $timeout, scope, compile, element, elementScope;
+
+    function createDirective (providedElement) {
+        element = angular.element('<div bst-alert="info"></div>');
+
+        if (providedElement) {
+            element = providedElement;
+        }
+
+        compile(element)(scope);
+        scope.$digest();
+        elementScope = element.isolateScope();
+    }
 
     beforeEach(module('Bastion.components', 'components/views/bst-alert.html'));
+
+    beforeEach(module(function ($provide) {
+        $animate = {
+            addClass: function () {},
+            removeClass: function () {},
+            cancel: function () {},
+            leave: function () {
+                return {
+                    then: function (callback) {
+                        callback();
+                    }
+                }
+            }
+        };
+
+        $timeout = function (callback) {
+            callback();
+        };
+
+        $provide.value('$animate', $animate);
+        $provide.value('$timeout', $timeout);
+    }));
 
     beforeEach(inject(function(_$compile_, _$rootScope_) {
         compile = _$compile_;
@@ -12,28 +43,76 @@ describe('Directive: bstAlert', function() {
     }));
 
     beforeEach(function() {
-        element = angular.element('<div bst-alert="info"></div>');
-
-        compile(element)(scope);
-        scope.$digest();
-
-        elementScope = element.isolateScope();
+        createDirective();
     });
 
     it("should display an alert", function() {
-        scope.successMessages = ['hello'];
-        scope.$digest();
-
         expect(element.find('.alert').length).toBe(1);
     });
 
     it("should display a close icon if a close function is provided", function () {
         element = angular.element('<div bst-alert="info" close="close()"></div>');
-
-        compile(element)(scope);
-        scope.$digest();
-        elementScope = element.isolateScope();
-
+        createDirective(element);
         expect(elementScope.closeable).toBe(true);
+    });
+
+    describe("can start the fade", function () {
+        beforeEach(function () {
+            spyOn($animate, 'leave').and.callThrough();
+            spyOn(elementScope, 'close');
+        });
+
+        it("and fades if the fade is not prevented", function () {
+            elementScope.fadePrevented = false;
+            elementScope.startFade();
+
+            expect($animate.leave).toHaveBeenCalled();
+            expect(elementScope.close).toHaveBeenCalled();
+        });
+
+        it("but does not fade if the fade is prevented", function () {
+            elementScope.fadePrevented = true;
+            elementScope.startFade();
+
+            expect($animate.leave).not.toHaveBeenCalled();
+            expect(elementScope.close).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("can cancel the fade", function () {
+        beforeEach(function () {
+            element = angular.element('<div bst-alert="success"></div>');
+            createDirective(element);
+        });
+
+        it("by setting fadePrevented", function () {
+            elementScope.cancelFade();
+            expect(elementScope.fadePrevented).toBe(true);
+        });
+
+        it("by calling $animate.cancel() if the animation is in progress", function () {
+            spyOn($animate, 'cancel');
+            elementScope.cancelFade();
+            expect($animate.cancel).toHaveBeenCalled();
+        });
+    });
+
+    describe("automatically starts the fade", function () {
+        beforeEach(function () {
+            spyOn($animate, 'leave').and.callThrough();
+        });
+
+        it("for success alerts", function () {
+            element = angular.element('<div bst-alert="success"></div>');
+            createDirective(element);
+            expect(elementScope.fadePrevented).toBe(false);
+            expect($animate.leave).toHaveBeenCalled();
+        });
+
+        it("but not for non-success alerts", function () {
+            createDirective();
+            expect(elementScope.fadePrevented).toBe(true);
+            expect($animate.leave).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
We are fading out success alerts after three seconds regadless of
whether the user wants it to fade, this commit keeps the alert in place
if the mouse is over it.

http://projects.theforeman.org/issues/15081