### PR TITLE
Fixes #17049: Update grunt-bower-task to 0.5.Z

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generator-bastion": "~0.1.2",
     "grunt": "~0.4.5",
     "grunt-angular-gettext": "~0.2.15",
-    "grunt-bower-task": "~0.3.4",
+    "grunt-bower-task": "yatskevich/grunt-bower-task#v0.5.0",
     "grunt-concurrent": "~1.0.0",
     "grunt-eslint": "~6.0.0",
     "grunt-htmlhint": "~0.4.1",


### PR DESCRIPTION
This fixes an installation issue where a much older bower is used.