### PR TITLE
Fixes #17099: don't save $location.search() between states.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -111,20 +111,9 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
 
         // Set the current language
         gettextCatalog.currentLanguage = currentLocale;
-        $rootScope.$on('$stateChangeStart',
-            function () {
-                //save location.search so we can add it back after transition is done
-                this.locationSearch = $location.search().search;
-            }
-        );
 
         $rootScope.$on('$stateChangeSuccess',
             function (event, toState, toParams, fromStateIn, fromParamsIn) {
-                //restore all query string parameters back to $location.search
-                if (this.locationSearch) {
-                    $location.search('search', this.locationSearch);
-                }
-
                 //Record our from state, so we can transition back there
                 if (!fromStateIn.abstract) {
                     fromState = fromStateIn;


### PR DESCRIPTION
We were saving $location.search() between state transitions which made
the search stay after changing to another state.  This commit removes
this logic.

http://projects.theforeman.org/issues/17099