### PR TITLE
Fixes #17350: ensure resource breadcrumbs show.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -70,14 +70,15 @@ angular.module('Bastion').config(
  * @requires currentLocale
  * @requires $location
  * @requires $window
+ * @requires $breadcrumb
  * @requires PageTitle
  * @requires markActiveMenu
  *
  * @description
  *   Set up some common state related functionality and set the current language.
  */
-angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', 'PageTitle', 'markActiveMenu',
-    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, PageTitle, markActiveMenu) {
+angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', '$breadcrumb', 'PageTitle', 'markActiveMenu',
+    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, $breadcrumb, PageTitle, markActiveMenu) {
         var fromState, fromParams, orgSwitcherRegex;
 
         $rootScope.$state = $state;

--- a/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
+++ b/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
@@ -15,6 +15,12 @@
 </div>
 
 <div class="row">
+  <header class="col-sm-12">
+    <span data-block="sub-header"></span>
+  </header>
+</div>
+
+<div class="row">
   <div class="col-sm-12 page-content">
     <div ng-hide="page && (page.loading || page.error)">
       <span data-block="content"></span>

--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -5,38 +5,40 @@
     </div>
   </div>
 
-  <div class="col-sm-3">
-    <div class="input-group input-group">
-      <input type="text"
-             class="form-control"
-             placeholder="{{ 'Filter...' | translate }}"
-             bst-on-enter="table.search(table.searchTerm)"
-             ng-model="table.searchTerm"
-             ng-trim="false"
-             typeahead="item.label for item in table.autocomplete($viewValue)"
-             typeahead-empty
-             typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
-        <span class="input-group-btn">
-          <button class="btn btn-default"
-                  type="button"
-                  ng-click='table.search("") && (table.searchCompleted = false)'
-                  ng-show="table.searchCompleted && table.searchTerm">
-            <i class="fa fa-times"></i>
-          </button>
-          <button ng-click="table.search(table.searchTerm)" class="btn btn-default" type="button">
-            <i class="fa fa-search"></i>
-            <span translate>Search</span>
-          </button>
-          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-            <i class="fa fa-caret-down"></i>
-          </button>
-          <ul bst-bookmark controller-name="controllerName" query="table.searchTerm" class="dropdown-menu pull-right"></ul>
-        </span>
-    </div>
-  </div>
+  <div data-block="search">
+    <div class="col-sm-3">
+      <div class="input-group">
+        <input type="text"
+               class="form-control"
+               placeholder="{{ 'Filter...' | translate }}"
+               bst-on-enter="table.search(table.searchTerm)"
+               ng-model="table.searchTerm"
+               ng-trim="false"
+               typeahead="item.label for item in table.autocomplete($viewValue)"
+               typeahead-empty
+               typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
+          <span class="input-group-btn">
+            <button class="btn btn-default"
+                    type="button"
+                    ng-click='table.search("") && (table.searchCompleted = false)'
+                    ng-show="table.searchCompleted && table.searchTerm">
+              <i class="fa fa-times"></i>
+            </button>
+            <button ng-click="table.search(table.searchTerm)" class="btn btn-default" type="button">
+              <span translate>Search</span>
+            </button>
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+              <i class="fa fa-caret-down"></i>
+            </button>
+            <ul bst-bookmark controller-name="controllerName" query="table.searchTerm" class="dropdown-menu pull-right"></ul>
+          </span>
 
-  <div class="col-sm-3">
-    <span translate>Showing {{ table.rows.length }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total)</span>
+      </div>
+    </div>
+
+    <div class="col-sm-3">
+      <span translate>Showing {{ table.rows.length }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total)</span>
+    </div>
   </div>
 
   <div class="fr">
@@ -56,7 +58,7 @@
 </div>
 
 <div class="row nutupane" bst-table="table" nutupane-table>
-  <div class="loading-mask" ng-show="table.refreshing" >
+  <div class="loading-mask" ng-show="table.refreshing || table.working" >
     <i class="fa fa-spinner fa-spin"></i>
     <span>{{ "Loading..." | translate }}</span>
   </div>


### PR DESCRIPTION
Breadcrumbs that include a $resource were not being displayed on page
reload.  This commit fixes that issue as well as makes the search
data-block of the table able to be replaced.

http://projects.theforeman.org/issues/17350