### PR TITLE
Fixes #17384: bring bst-alert inline with patternfly.

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-alert.html
+++ b/app/assets/javascripts/bastion/components/views/bst-alert.html
@@ -2,15 +2,11 @@
   <button ng-show="closeable" type="button" class="close" aria-hidden="true" ng-click="close()">
     <span class="pficon pficon-close"></span>
   </button>
-  <span class="pficon-layered">
-      <span ng-show="type === 'danger'" class="pficon pficon-error-circle-o"></span>
 
-      <span ng-show="type === 'warning'" class="pficon pficon-warning-circle-o"></span>
+  <span ng-show="type === 'danger'" class="pficon pficon-error-circle-o"></span>
+  <span ng-show="type === 'warning'" class="pficon pficon-warning-circle-o"></span>
+  <span ng-show="type === 'info'" class="pficon pficon-info"></span>
+  <span ng-show="type === 'success'" class="pficon pficon-ok"></span>
 
-      <span ng-show="type === 'info'" class="pficon pficon-info"></span>
-
-      <span ng-show="type === 'success'" class="pficon pficon-ok"></span>
-  </span>
-
-  <div ng-transclude></div>
+  <span ng-transclude></span>
 </div>

--- a/app/assets/stylesheets/bastion/overrides.scss
+++ b/app/assets/stylesheets/bastion/overrides.scss
@@ -5,20 +5,8 @@
   font-weight: normal;
 }
 
-.alert {
-  margin: 10px;
-
-  ul {
-    list-style: none;
-  }
-
-  p {
-    margin-bottom: 0;
-  }
-
-  div {
-    display: inline;
-  }
+.alert ul {
+  list-style: none;
 }
 
 // Patternfly Overrides


### PR DESCRIPTION
The markup and styling for bst-alert was not following what patternfly
lays out as the proper markup.  This commit fixes the problems.

http://projects.theforeman.org/issues/17384