### PR TITLE
Fixes #17385: use normal BS3 forms instead of horizontal.

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-form-buttons.html
+++ b/app/assets/javascripts/bastion/components/views/bst-form-buttons.html
@@ -1,10 +1,8 @@
-<div class="form-group">
-  <div class="col-sm-offset-2 col-sm-4">
-    <div bst-save-control
-         on-cancel="handleCancel()"
-         on-save="handleSave()"
-         invalid="isInvalid()"
-         working="working">
-    </div>
+<div>
+  <div bst-save-control
+       on-cancel="handleCancel()"
+       on-save="handleSave()"
+       invalid="isInvalid()"
+       working="working">
   </div>
 </div>

--- a/app/assets/javascripts/bastion/components/views/bst-form-group.html
+++ b/app/assets/javascripts/bastion/components/views/bst-form-group.html
@@ -1,9 +1,7 @@
 <div class="form-group" ng-class="{ 'has-error' : hasErrors() }">
-  <label for="{{ field }}" class="control-label col-sm-2">{{ label }}</label>
-  <div class="col-sm-5 input"> 
-    <span ng-transclude></span>
-    <span class="help-block" ng-show="error.messages">
-      <ul><li ng-repeat="message in error.messages">{{ message }}</li></ul>
-    </span>
-  </div>
+  <label for="{{ field }}">{{ label }}</label>
+  <div ng-transclude></div>
+  <span class="help-block" ng-show="error.messages">
+    <ul><li ng-repeat="message in error.messages">{{ message }}</li></ul>
+  </span>
 </div>

--- a/app/assets/javascripts/bastion/components/views/bst-save-control.html
+++ b/app/assets/javascripts/bastion/components/views/bst-save-control.html
@@ -1,12 +1,4 @@
 <div class="control-group buttons">
-  <button class="btn btn-default"
-          type="button"
-          ng-click="handleCancel()"
-          ng-disabled="working"
-          translate>
-    Cancel
-  </button>
-
   <button class="btn btn-primary"
           ng-click="handleSave(); working = true"
           ng-disabled="invalid || working">
@@ -14,5 +6,13 @@
     <i class="fa fa-spinner fa-spin" ng-show="working"></i>
     <span ng-show="working" translate>Saving...</span>
     <span ng-hide="working" translate>Save</span>
+  </button>
+
+  <button class="btn btn-default"
+          type="button"
+          ng-click="handleCancel()"
+          ng-disabled="working"
+          translate>
+    Cancel
   </button>
 </div>


### PR DESCRIPTION
With non-nutupane we now have an excess of vertical space so we ought to
use regular boostrap 3 forms instead of horizontal forms.

http://projects.theforeman.org/issues/17385