### PR TITLE
Fixes #17416: add magic id so foreman topbar works properly.

### DIFF
--- a/app/views/bastion/layouts/application.html.erb
+++ b/app/views/bastion/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:content) do %>
-  <div class="article maincontent bastion" data-no-turbolink="true">
+  <div id="content" class="article maincontent bastion" data-no-turbolink="true">
     <section class="container-fluid">
         <div ui-view></div>
     </section>


### PR DESCRIPTION
Apparently foreman's topbar JS requries a #content element to function
properly.  This commit adds that element so you don't see odd scrolling
behavior when the page is just small enough.

http://projects.theforeman.org/issues/17416