### PR TITLE
Fixes #17549: add /pulp to list to not remove trailing slash.

### DIFF
--- a/app/assets/javascripts/bastion/routing.module.js
+++ b/app/assets/javascripts/bastion/routing.module.js
@@ -14,7 +14,7 @@ angular.module('Bastion.routing', ['ui.router']);
      *   Routing configuration for Bastion.
      */
     function bastionRouting($stateProvider, $urlRouterProvider, $locationProvider) {
-        var oldBrowserBastionPath = '/bastion#', getRootPath;
+        var oldBrowserBastionPath = '/bastion#', getRootPath, shouldRemoveTrailingSlash;
 
         getRootPath = function (path) {
             var rootPath = null;
@@ -23,6 +23,16 @@ angular.module('Bastion.routing', ['ui.router']);
                 rootPath = path.replace('_', '-').split('/')[1];
             }
             return rootPath;
+        };
+
+        shouldRemoveTrailingSlash = function (path) {
+            var whiteList = ['pulp'], remove = true;
+
+            if (path.split('/')[1] && whiteList.indexOf(path.split('/')[1]) >= 0) {
+                remove = false;
+            }
+
+            return remove;
         };
 
         $stateProvider.state('404', {
@@ -39,8 +49,8 @@ angular.module('Bastion.routing', ['ui.router']);
                 $window.location.href = oldBrowserBastionPath + $location.path();
             }
 
-            // removing trailing slash to prevent endless redirect
-            if (path[path.length - 1] === '/') {
+            // removing trailing slash to prevent endless redirect if not in ignore list
+            if (path[path.length - 1] === '/' && shouldRemoveTrailingSlash(path)) {
                 return path.slice(0, -1);
             }
         });

--- a/test/routing.module.test.js
+++ b/test/routing.module.test.js
@@ -35,6 +35,11 @@ describe('config: Bastion.routing', function () {
             goTo('/state///');
             expect($window.location.href).toBe('http://server/state');
         });
+
+        it("doesn't remove slashes if whitelisted", function () {
+            goTo('/pulp/repos/');
+            expect($window.location.href).toBe('http://server/pulp/repos/');
+        });
     });
 
     describe("provides an otherwise method that", function () {


### PR DESCRIPTION
Removing the trailing slash from Pulp URLs breaks them so this change
adds an ignore list so we don't remove the trailing slash from these
URLs.
    
http://projects.theforeman.org/issues/17549