### PR TITLE
Fixes #17537: trigger reize event on load to fix tasks table.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane-table.directive.js
+++ b/app/assets/javascripts/bastion/components/nutupane-table.directive.js
@@ -70,6 +70,7 @@ angular.module('Bastion.components').directive('nutupaneTable', ['$compile', '$w
             });
 
             buildTable();
+            windowElement.trigger('resize');
         }
     };
 }]);


### PR DESCRIPTION
The tasks table wasn't being rendered correctly on load so fixing this
by triggering a reload event on the load of the nutupane table.

http://projects.theforeman.org/issues/17537