### PR TITLE
Fixes #17638: show filters on non row select tables.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -48,11 +48,11 @@
   </div>
 </div>
 
-<div class="row header-bar" ng-show="table.rowSelect">
-  <div class="fr">
+<div class="row header-bar">
+  <div class="fr" ng-show="table.rowSelect">
     <span translate>{{ table.numSelected }} Selected</span>
   </div>
-  <div class="col-sm-5">
+  <div class="col-sm-10">
     <span data-block="filters"></span>
   </div>
 </div>


### PR DESCRIPTION
We are currently hiding filters if the table doesn't include the ability
to select rows, we should show filters in this case.

http://projects.theforeman.org/issues/17638