### PR TITLE
Fixes #17647: add missing data-blocks to layout.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/table-with-header.html
+++ b/app/assets/javascripts/bastion/layouts/table-with-header.html
@@ -4,9 +4,12 @@
     <span data-block="item-actions"></span>
   </div>
 
-  <div data-extend-template="layouts/partials/messages-container.html"></div>
+  <div data-extend-template="layouts/partials/messages-container.html">
+    <span data-block="messages"></span>
+  </div>
 
   <div data-extend-template="layouts/partials/table.html">
+    <span data-block="search-filter"></span>
     <span data-block="list-actions"></span>
     <span data-block="no-rows-message"></span>
     <span data-block="no-search-results-message"></span>


### PR DESCRIPTION
The table-with-header layout is missing the "passthrough" data-blocks
messages and search-filter.  This commit adds those data blocks.

http://projects.theforeman.org/issues/17647