### PR TITLE
Fixes #17688: fix class for patternfly alert warning icon.

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-alert.html
+++ b/app/assets/javascripts/bastion/components/views/bst-alert.html
@@ -4,7 +4,7 @@
   </button>
 
   <span ng-show="type === 'danger'" class="pficon pficon-error-circle-o"></span>
-  <span ng-show="type === 'warning'" class="pficon pficon-warning-circle-o"></span>
+  <span ng-show="type === 'warning'" class="pficon pficon-warning-triangle-o"></span>
   <span ng-show="type === 'info'" class="pficon pficon-info"></span>
   <span ng-show="type === 'success'" class="pficon pficon-ok"></span>
 


### PR DESCRIPTION
The warning icon was using the wrong class and thus not being displayed,
this commit corrects the class.

http://projects.theforeman.org/issues/17688