### PR TITLE
Fixes #17848: allow modal template url to be specified.

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-modal.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-modal.directive.js
@@ -15,17 +15,21 @@ angular.module('Bastion.components').directive('bstModal',
         scope: {
             action: '&bstModal',
             modelName: '@model',
-            model: '='
+            model: '=',
+            templateUrl: '@'
         },
-        compile: function(tElement) {
-            var template = angular.element('<div extend-template="components/views/bst-modal.html"></div>'), modalId;
+        compile: function(tElement, tAttrs) {
+            var template = angular.element('<div extend-template="components/views/bst-modal.html"></div>'),
+                templateUrl = tAttrs.templateUrl;
 
-            template.append(tElement.children());
-            tElement.html('');
-            tElement = angular.element(template);
+            if (!templateUrl) {
+                template.append(tElement.children());
+                tElement.html('');
+                tElement = angular.element(template);
 
-            modalId = 'bstModal%d.html'.replace('%d', Math.random().toString());
-            $templateCache.put(modalId, tElement);
+                templateUrl = 'bstModal%d.html'.replace('%d', Math.random().toString());
+                $templateCache.put(templateUrl, tElement);
+            }
 
             return function (scope) {
                 var modalInstance, modalController;
@@ -44,7 +48,7 @@ angular.module('Bastion.components').directive('bstModal',
 
                 scope.openModal = function () {
                     modalInstance = $uibModal.open({
-                        templateUrl: modalId,
+                        templateUrl: templateUrl,
                         controller: modalController,
                         resolve: {
                             model: function () {

--- a/app/assets/javascripts/bastion/components/views/bst-modal.html
+++ b/app/assets/javascripts/bastion/components/views/bst-modal.html
@@ -9,8 +9,10 @@
   <p data-block="modal-body"></p>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-danger" ng-click="ok()">
-    <span data-block="modal-confirm-button" translate>Remove</span>
-  </button>
-  <button class="btn btn-default" ng-click="cancel()" translate>Cancel</button>
+  <div data-block="modal-footer">
+    <button class="btn btn-danger" ng-click="ok()">
+      <span data-block="modal-confirm-button" translate>Remove</span>
+    </button>
+    <button class="btn btn-default" ng-click="cancel()" translate>Cancel</button>
+  </div>
 </div>

--- a/test/components/bst-modal.directive.test.js
+++ b/test/components/bst-modal.directive.test.js
@@ -74,4 +74,18 @@ describe('Directive: bstModal', function() {
 
         expect($uibModal.open).toHaveBeenCalled();
     });
+    
+    it("allows the specification of a modal templateUrl", function() {
+        var html = '<span bst-modal="item.delete(item)" template-url="blah.html"></span>';
+
+        element = angular.element(html);
+        compile(element)(scope);
+        scope.$digest();
+
+        spyOn($uibModal, 'open').and.callThrough();
+
+        elementScope.openModal();
+
+        expect($uibModal.open.calls.mostRecent().args[0].templateUrl).toBe('blah.html');
+    });
 });


### PR DESCRIPTION
Instead of requiring transclusion of a template, allow the modal
template to be specified via a template URL if desired.

http://projects.theforeman.org/issues/17848