### PR TITLE
Fixes #17946: remove preceding - from table cache name.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -37,7 +37,7 @@ angular.module('Bastion.components').factory('Nutupane',
                 orgSwitcherRegex = new RegExp("/(organizations|locations)/(.+/)*(select|clear)");
 
             function getTableName() {
-                return $location.path().split('/').join('-');
+                return $location.path().split('/').join('-').slice(1);
             }
 
             params = params || {};


### PR DESCRIPTION
The nutupane factory was saving tables with a - at the beginning of the
name.  This commit removes the - at the front of the saved table name.

http://projects.theforeman.org/issues/17946