### PR TITLE
Fixes #17945: make color rules for table css less broad.

### DIFF
--- a/app/assets/stylesheets/bastion/nutupane.scss
+++ b/app/assets/stylesheets/bastion/nutupane.scss
@@ -47,8 +47,8 @@ td.row-select {
   .table {
     margin-bottom: 0;
 
-    tr:hover td, tr:hover td a,
-    tr.focus td, tr.focus td a {
+    tr:hover td, tr:hover td > a,
+    tr.focus td, tr.focus td > a {
       background-color: $listhover_color;
       color: #FFF;
 
@@ -61,7 +61,7 @@ td.row-select {
       background-color: $listhover_color;
       color: #FFF;
 
-      a {
+      > a {
         color: #FFF;
       }
 
@@ -110,7 +110,7 @@ td.row-select {
       background-color: lighten($listhover_color, 8%);
       color: white;
 
-      a {
+      > a {
         color: white;
       }
     }


### PR DESCRIPTION
The color styles for table rows are too broad and cause the coloring in
row items (dropdowns, for example) to be incorrect.

http://projects.theforeman.org/issues/17945