### PR TITLE
Fixes #18038: enforce consistent header weights. 

### DIFF
--- a/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
+++ b/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
@@ -16,7 +16,9 @@
 
 <div class="row">
   <header class="col-sm-12">
-    <span data-block="sub-header"></span>
+    <h3>
+      <span data-block="sub-header"></span>
+    </h3>
   </header>
 </div>
 

--- a/app/assets/javascripts/bastion/layouts/partials/page-header-with-actions.html
+++ b/app/assets/javascripts/bastion/layouts/partials/page-header-with-actions.html
@@ -1,9 +1,13 @@
-<div class="row header-bar">
-  <div class="col-sm-10">
-    <span data-block="header"></span>
+<div class="row">
+  <div class="col-sm-9">
+    <h1>
+      <span data-block="header"></span>
+    </h1>
   </div>
 
-  <div class="fr">
-    <span data-block="item-actions"></span>
+  <div class="col-sm-3">
+    <h1 class="fr">
+      <span data-block="item-actions"></span>
+    </h1>
   </div>
 </div>


### PR DESCRIPTION
Use `<h1>` instead of `<h2>` in details page header and enforce `<h3>` in
sub-header.

http://projects.theforeman.org/issues/18038