### PR TITLE
Fixes #18160: remove unused sub-header angular-block.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
+++ b/app/assets/javascripts/bastion/layouts/details-page-with-breadcrumbs.html
@@ -15,14 +15,6 @@
 </div>
 
 <div class="row">
-  <header class="col-sm-12">
-    <h3>
-      <span data-block="sub-header"></span>
-    </h3>
-  </header>
-</div>
-
-<div class="row">
   <div class="col-sm-12 page-content">
     <div ng-hide="page && (page.loading || page.error)">
       <span data-block="content"></span>


### PR DESCRIPTION
The sub-header angular-block was not being used because it was being
called from inside the content angular-block and was thus inaccessible.
However because of the `<h3>` surrounding the block it would cause spacing
issues on details pages.

http://projects.theforeman.org/issues/18160