### PR TITLE
Fixes #15665: get correct root url for 404 states.

### DIFF
--- a/app/assets/javascripts/bastion/routing.module.js
+++ b/app/assets/javascripts/bastion/routing.module.js
@@ -70,9 +70,11 @@ angular.module('Bastion.routing', ['ui.router']);
 
             if (rootPath) {
                 foundParentState = _.find($state.get(), function (state) {
-                    var found = false;
-                    if (state.url) {
-                        found = getRootPath(state.url) === rootPath;
+                    var found = false,
+                        stateUrl = $state.href(state);
+
+                    if (stateUrl) {
+                        found = getRootPath(stateUrl) === rootPath;
                     }
 
                     return found;

--- a/test/routing.module.test.js
+++ b/test/routing.module.test.js
@@ -57,6 +57,7 @@ describe('config: Bastion.routing', function () {
         describe("handles undefined states by", function () {
             it("redirecting to a 404 page if the parent state is found", function () {
                 spyOn($state, 'get').and.returnValue([{url: '/found-state'}]);
+                spyOn($state, 'href').and.returnValue('/found-state');
                 spyOn($state, 'go');
 
                 goTo('/found_state/does_not_exist');


### PR DESCRIPTION
We were getting the relative url instead of an absolute url when
determining if a state transition should result in a 404 (which worked
until nutupane was removed).  This commit fixes the root url logic.

http://projects.theforeman.org/issues/15665