### PR TITLE
Fixes #18243: show typeahead on inital focus.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -53,7 +53,7 @@ angular.module('Bastion.components').factory('Nutupane',
                 params: params,
                 resource: resource,
                 rows: [],
-                searchTerm: $location.search()[self.searchKey],
+                searchTerm: $location.search()[self.searchKey] || "",
                 initialLoad: true
             };
 

--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -15,7 +15,8 @@
                    ng-model="table.searchTerm"
                    ng-trim="false"
                    uib-typeahead="item.label for item in table.autocomplete($viewValue)"
-                   typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
+                   typeahead-template-url="components/views/autocomplete-scoped-search.html"
+                   typeahead-min-length="0"/>
 
           <span class="input-group-btn">
             <button class="btn btn-default"


### PR DESCRIPTION
Instead of making the user guess the first letter of the search they
want we should show the typeahead on initial focus.

http://projects.theforeman.org/issues/18243