### PR TITLE
Fixes #18184: move search filters to left of search.

### DIFF
--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -1,11 +1,11 @@
 <div class="row toolbar-pf table-view-pf-toolbar-external" ng-class="{'empty-table': table.rows.length === 0}">
   <div class="col-sm-12">
     <form class="toolbar-pf-actions">
-      <div class="toolbar-pf-action-right">
-        <div data-block="list-actions"></div>
-      </div>
-
       <div class="form-group toolbar-pf-filter">
+        <div class="form-group toolbar-pf-search-filter">
+          <span data-block="search-filter"></span>
+        </div>
+
         <div data-block="search">
           <div class="input-group">
             <input type="text"
@@ -35,9 +35,14 @@
           </span>
           </div>
         </div>
+      </div>
 
+      <div class="form-group">
         <span data-block="filters"></span>
-        <span data-block="search-filter"></span>
+      </div>
+
+      <div class="toolbar-pf-action-right">
+        <div data-block="list-actions"></div>
       </div>
     </form>
 

--- a/app/assets/stylesheets/bastion/overrides.scss
+++ b/app/assets/stylesheets/bastion/overrides.scss
@@ -64,6 +64,11 @@ html .toolbar-pf .toolbar-pf-filter.form-group .input-group-btn .btn {
   margin-left: -1px;
 }
 
+// Increase size of .toolbar-pf-filter
+html .toolbar-pf.table-view-pf-toolbar-external .toolbar-pf-filter {
+  width: 35%;
+}
+
 // Add border to bottom of empty table
 .row.toolbar-pf.table-view-pf-toolbar.empty-table{
   border-bottom: 1px solid #d1d1d1;

--- a/app/assets/stylesheets/bastion/tables.scss
+++ b/app/assets/stylesheets/bastion/tables.scss
@@ -48,3 +48,12 @@
   }
 }
 
+.table-view-pf-toolbar-external .toolbar-pf-actions .form-group.toolbar-pf-search-filter {
+  border-right: none;
+  padding-left: 0;
+
+  select {
+    display: inline;
+    width: 150px;
+  }
+}


### PR DESCRIPTION
Instead of displaying the search filters underneath the search we
should display them to the left of the search.

http://projects.theforeman.org/issues/18184