### PR TITLE
Fixes #18306: include vendor style sheets.

### DIFF
--- a/lib/bastion/engine.rb
+++ b/lib/bastion/engine.rb
@@ -14,6 +14,10 @@ module Bastion
       app.routes_reloader.paths.unshift("#{Bastion::Engine.root}/config/routes.rb")
     end
 
+    initializer "bastion.assets", :group => :all do |app|
+      app.config.assets.paths << "#{Bastion::Engine.root}/vendor/assets/stylesheets/bastion"
+    end
+
     initializer "bastion.configure_assets", :group => :all do |app|
       SETTINGS[:bastion] = {:assets => {}} if SETTINGS[:bastion].nil?
 


### PR DESCRIPTION
When we switched over to use foreman's copy of patternfly we also
removed the ability to include vendor css files into bastion. We should
revert this change so we can use vendor css files when needed.

http://projects.theforeman.org/issues/18306