### PR TITLE
Fixes #18937: allow modal confirm button to be specified.

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-bookmark.html
+++ b/app/assets/javascripts/bastion/components/views/bst-bookmark.html
@@ -42,5 +42,9 @@
       </div>
     </form>
   </div>
-  <div data-block="modal-confirm-button" translate>Save</div>
+  <span data-block="modal-confirm-button">
+    <button class="btn btn-primary" ng-click="ok()">
+      <span translate>Save</span>
+    </button>
+  </span>
 </div>

--- a/app/assets/javascripts/bastion/components/views/bst-modal.html
+++ b/app/assets/javascripts/bastion/components/views/bst-modal.html
@@ -10,9 +10,11 @@
 </div>
 <div class="modal-footer">
   <div data-block="modal-footer">
-    <button class="btn btn-danger" ng-click="ok()">
-      <span data-block="modal-confirm-button" translate>Remove</span>
-    </button>
+    <span data-block="modal-confirm-button">
+      <button class="btn btn-danger" ng-click="ok()">
+        <span translate>Remove</span>
+      </button>
+    </span>
     <button class="btn btn-default" ng-click="cancel()" translate>Cancel</button>
   </div>
 </div>


### PR DESCRIPTION
Instead of assuming all modals have a .btn-danger we should allow the
confirm button to be specified.

http://projects.theforeman.org/issues/18937