### PR TITLE
Fixes #19139 fix incorrect font and weight in path selector.

### DIFF
--- a/app/assets/javascripts/bastion/components/views/path-selector.html
+++ b/app/assets/javascripts/bastion/components/views/path-selector.html
@@ -3,7 +3,8 @@
     <li class="path-list-item" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
       <label class="path-list-item-label" ng-disabled="item.disabled" ng-class="{ active: item.selected }" ng-mouseenter="hover" ng-mouseleave="hover = false">
         <input type="checkbox" ng-model="item.selected" ng-change="itemChanged(item)" ng-disabled="item.disabled"/>
-          <span ng-class="item.customClass">{{ item.name }}</span>
+          <i ng-class="item.iconClass"></i>
+          {{ item.name }}
       </label>
     </li>
   </ul>


### PR DESCRIPTION
The path selector was being provided an icon class for the text in the
suggested path selector.  This commit makes the icon class a separate
element instead of wrapping the text within the icon.

http://projects.theforeman.org/issues/19139