### PR TITLE
Fixes #19167: fix styling of unordered lists.

### DIFF
--- a/app/assets/stylesheets/bastion/overrides.scss
+++ b/app/assets/stylesheets/bastion/overrides.scss
@@ -21,12 +21,6 @@ table.table {
   background: inherit;
 }
 
-ul {
-  -webkit-padding-start: 0;
-  -moz-padding-start: 0;
-  padding-start: 0;
-}
-
 // Prevent Foreman editable icon from bleeding into our pages
 .editable {
   background: inherit;

--- a/app/assets/stylesheets/bastion/path-selector.scss
+++ b/app/assets/stylesheets/bastion/path-selector.scss
@@ -9,6 +9,13 @@ $path-active-color: #005870;
 .path-selector {
   margin-top: 20px;
 
+  ul {
+    -webkit-padding-start: 0;
+    -moz-padding-start: 0;
+    padding-start: 0;
+  }
+
+
   .path-list {
     list-style: none;
     overflow: hidden;


### PR DESCRIPTION
Ensure the rule for path selector unordered lists only applies to path
selector unordered lists.

http://projects.theforeman.org/issues/19167