### PR TITLE
Fixes #18203: override hover colors on .info-blocks.

### DIFF
--- a/app/assets/stylesheets/bastion/bastion.scss
+++ b/app/assets/stylesheets/bastion/bastion.scss
@@ -146,22 +146,6 @@
     }
   }
 
-  .info-blocks {
-    margin-top: 20px;
-    margin-bottom: 20px;
-
-    .info-block-head {
-      font-size: 18px;
-      padding-left: 15px;
-      padding-top: 18px;
-      background: #F7F7F7;
-    }
-
-    .info-block {
-      text-align: center;
-    }
-  }
-
   .details-page {
     padding-top: 20px;
 

--- a/app/assets/stylesheets/bastion/components.scss
+++ b/app/assets/stylesheets/bastion/components.scss
@@ -1,3 +1,6 @@
+@import "bootstrap/variables";
+@import "variables";
+
 .nav.nav-tabs.details-nav {
   margin-bottom: 10px;
 }
@@ -18,5 +21,40 @@
   dd {
     margin-left: 200px;
     word-wrap: break-word;
+  }
+}
+
+.info-blocks {
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  tr:hover td > a,
+  tr.focus td > a
+  {
+    color: $link-color;
+  }
+
+  tr:hover td:not(.info-block-head),
+  tr.focus td:not(.info-block-head)
+   {
+    background-color: $body-bg;
+    color: $text-color;
+  }
+
+  .info-block-head,
+  tr:hover td.info-block-head,
+  tr.focus td.info-block-head,
+  {
+    background: #F7F7F7;
+  }
+
+  .info-block-head {
+    font-size: 18px;
+    padding-left: 15px;
+    padding-top: 18px;
+  }
+
+  .info-block {
+    text-align: center;
   }
 }

--- a/app/assets/stylesheets/bastion/nutupane.scss
+++ b/app/assets/stylesheets/bastion/nutupane.scss
@@ -45,8 +45,8 @@ td.row-select {
 
     tr:hover td, tr:hover td > a,
     tr.focus td, tr.focus td > a {
-      background-color: $listhover_color;
-      color: #FFF;
+      background-color: $hover-bg-color;
+      color: $hover-color;
 
       button, select {
         color: #000;
@@ -54,11 +54,11 @@ td.row-select {
     }
 
     tr.active, tbody tr:hover, tr.selected-row td {
-      background-color: $listhover_color;
-      color: #FFF;
+      background-color: $hover-bg-color;
+      color: $hover-color;
 
       > a {
-        color: #FFF;
+        color: $hover-color;
       }
 
       .bst-edit:hover {
@@ -103,11 +103,11 @@ td.row-select {
     }
 
     td.active-row {
-      background-color: lighten($listhover_color, 8%);
-      color: white;
+      background-color: lighten($hover-bg-color, 8%);
+      color: $hover-color;
 
       > a {
-        color: white;
+        color: $hover-color;
       }
     }
 
@@ -367,8 +367,8 @@ div.alch-dialog.open.info-value {
         color: black;
 
         &:hover {
-            color: $listhover_color;
-            border-bottom: 2px solid $listhover_color;
+            color: $hover-color;
+            border-bottom: 2px solid $hover-bg-color;
         }
 
         &:first-child {
@@ -379,8 +379,8 @@ div.alch-dialog.open.info-value {
     .active {
 
       a {
-        color: $listhover_color;
-        border-bottom: 2px solid $listhover_color;
+        color: $hover-bg-color;
+        border-bottom: 2px solid $hover-bg-color;
       }
     }
 

--- a/app/assets/stylesheets/bastion/path-selector.scss
+++ b/app/assets/stylesheets/bastion/path-selector.scss
@@ -1,7 +1,9 @@
+@import "variables";
+
 $widget-border-color: #D7D7D7;
 $widget-background-color: #F9F8F8;
 $breadcrumbbg_color: #e9e9e9;
-$listhover_color: #00a8d6;
+$hover-bg-color: #00a8d6;
 $path-item-color: #FFF;//#e9e9e9;
 $disabled-item-color: #e9e9e9;
 $path-active-color: #005870;
@@ -39,13 +41,13 @@ $path-active-color: #005870;
           padding-right: 16px;
 
           &:hover:not([disabled]) {
-            color: white;
-            background: $listhover_color;
+            color: $hover-color;
+            background: $hover-bg-color;
           }
           &:after {
             border: 0;
             border-left: 0px solid $breadcrumbbg_color;
-            &:hover { border-left-color: $listhover_color; }
+            &:hover { border-left-color: $hover-bg-color; }
           }
         }
       }
@@ -66,12 +68,12 @@ $path-active-color: #005870;
           color: white;
           text-shadow: 1px 1px #000;
           &:after { border-left-color: $path-active-color; };
-          &:hover:after { border-left-color: $listhover_color; }
+          &:hover:after { border-left-color: $hover-bg-color; }
         }
         &:hover:not([disabled])  {
-          background: $listhover_color;
-          color: white;
-          &:after { border-left-color: $listhover_color; }
+          background: $hover-bg-color;
+          color: $hover-color;
+          &:after { border-left-color: $hover-bg-color; }
         }
         &:after {
           content: " ";

--- a/app/assets/stylesheets/bastion/tables.scss
+++ b/app/assets/stylesheets/bastion/tables.scss
@@ -26,22 +26,19 @@
     max-width: $row-select-width;
   }
 
-  tr:hover td, tr:hover td > a,
-  tr.focus td, tr.focus td > a {
-    background-color: $listhover_color;
-    color: #FFF;
+  tr.active td,
+  tr:hover td,
+  tr.focus td,
+  tr.selected-row td {
+    background-color: $hover-bg-color;
+    color: $hover-color;
+
+    > a {
+      color: $hover-color;
+    }
 
     button, select {
       color: #000;
-    }
-  }
-
-  tr.active, tbody tr:hover, tr.selected-row td {
-    background-color: $listhover_color;
-    color: #FFF;
-
-    > a {
-      color: #FFF;
     }
 
     .bst-edit:hover {

--- a/app/assets/stylesheets/bastion/variables.scss
+++ b/app/assets/stylesheets/bastion/variables.scss
@@ -1,4 +1,5 @@
-$listhover_color: rgb(0, 153, 211);
+$hover-color: #FFF;
+$hover-bg-color: rgb(0, 153, 211);
 $label-color: #000;
 $border_color: #d7d7d7;
 $grid-gutter-width: 30px;


### PR DESCRIPTION
Instead of highlighting .info-blocks with the same color as tables we
should override the highlighting to be the normal page colors.

http://projects.theforeman.org/issues/18203