### PR TITLE
Fixes #18342: unselect all when table is refreshed.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -223,6 +223,7 @@ angular.module('Bastion.components').factory('Nutupane',
 
                 self.table.refreshing = true;
                 self.table.numSelected = 0;
+                self.table.selectAllResults(false);
                 return self.load();
             };
 


### PR DESCRIPTION
Ensure that the select all checkbox (and all selections) are removed
when the table is refreshed.

http://projects.theforeman.org/issues/18342