### PR TITLE
Fixes #18404: show no rows message inside table.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -352,6 +352,16 @@ angular.module('Bastion.components').factory('Nutupane',
                 return (pageNumber >= 1) && (pageNumber <= self.table.getLastPage());
             };
 
+            self.table.getPageStart = function () {
+                var table = self.table, pageStart = 0;
+
+                if (table.rows.length > 0) {
+                    pageStart = table.resource.offset;
+                }
+
+                return pageStart;
+            };
+
             self.table.getPageEnd = function () {
                 var table = self.table, pageEnd;
 

--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -1,4 +1,4 @@
-<div class="row toolbar-pf table-view-pf-toolbar-external" ng-class="{'empty-table': table.rows.length === 0}">
+<div class="row toolbar-pf table-view-pf-toolbar-external">
   <div class="col-sm-12">
     <form class="toolbar-pf-actions">
       <div class="form-group toolbar-pf-search-filter">
@@ -47,10 +47,10 @@
       </div>
     </form>
 
-    <div class="row toolbar-pf-results" ng-show="table.rows.length > 0">
+    <div class="row toolbar-pf-results">
       <div class="col-sm-9"></div>
       <div class="col-sm-3 table-view-pf-select-results" ng-show="table.rowSelect">
-        <span translate>{{ table.numSelected }} of {{ table.resource.total }} Selected</span>
+        <span translate>{{ table.numSelected }} of {{ table.resource.subtotal }} Selected</span>
       </div>
     </div>
   </div>
@@ -59,14 +59,14 @@
 <div bst-table="table">
   <div class="row">
     <div class="col-sm-12">
-      <p bst-alert="info" ng-show="table.rows.length === 0 && !table.working && !table.searchTerm && !table.searchCompleted">
+      <p id="noRowsMessage" ng-show="false">
         <span data-block="no-rows-message"></span>
       </p>
-      <p bst-alert="info" ng-show="table.rows.length === 0 && !table.working && (table.searchTerm || table.searchCompleted)">
+      <p id="noSearchResultsMessage" ng-show="false">
         <span data-block="no-search-results-message"></span>
       </p>
 
-      <div ng-show="table.rows.length > 0" ng-class="{'table-mask': table.refreshing || table.working}">
+      <div ng-class="{'table-mask': table.refreshing || table.working}">
         <div data-block="table"></div>
 
         <form class="content-view-pf-pagination table-view-pf-pagination clearfix">
@@ -80,7 +80,7 @@
           </div>
           <div class="form-group">
             <span>
-              <span class="pagination-pf-items-current">{{ table.resource.offset }} - {{ table.getPageEnd() }}</span>
+              <span class="pagination-pf-items-current" translate>Showing {{ table.getPageStart() }} - {{ table.getPageEnd() }}</span>
               <span translate>of </span>
               <span class="pagination-pf-items-total">{{ table.resource.subtotal }}</span>
             </span>
@@ -100,7 +100,11 @@
             <label for="currentPage" class="sr-only" translate>
               Current Page
             </label>
-            <input id="currentPage" class="pagination-pf-page" type="text" ng-model="table.params.page" ng-blur="table.changePage(table.params.page)" bst-on-enter="table.changePage()"/>
+
+            <input id="currentPage" ng-show="table.resource.subtotal > 0" class="pagination-pf-page" type="text" ng-model="table.params.page"
+                   ng-blur="table.changePage(table.params.page)" bst-on-enter="table.changePage()"/>
+
+            <input ng-show="table.resource.subtotal === 0" class="pagination-pf-page" type="text" readonly="true" ng-value="table.resource.subtotal"/>
 
             <span translate>of
               <span class="pagination-pf-pages">{{ (table.resource.subtotal / table.resource.per_page) | roundUp }}</span>

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -42,7 +42,7 @@ describe('Factory: Nutupane', function() {
             per_page: 2,
             total: 10,
             subtotal: 8,
-            offset: 5,
+            offset: 1,
             sort: {
                 by: "description",
                 order: "ASC"
@@ -225,9 +225,14 @@ describe('Factory: Nutupane', function() {
             expect(nutupane.table.pageExists(23524)).toBe(false);
         });
 
+        it("provides a way to get the page start based on offset", function () {
+            expect(nutupane.table.getPageStart()).toBe(1);
+            nutupane.table.rows = [];
+            expect(nutupane.table.getPageStart()).toBe(0);
+        });
 
         it("provides a way to get the page end based on offset", function () {
-            expect(nutupane.table.getPageEnd()).toBe(6);
+            expect(nutupane.table.getPageEnd()).toBe(2);
         });
 
         describe("provides page navigation", function () {


### PR DESCRIPTION
Instead of showing the no rows message as an overused alert we should
just simply show it as a p.  Also we should show the total count of rows
so it's even more obvious that the table is empty.

http://projects.theforeman.org/issues/18404

Instead of this:

![screen shot 2017-05-12 at 10 02 15 am](https://cloud.githubusercontent.com/assets/4116405/26001369/24f13c2a-36fa-11e7-9882-8c88434ae4db.png)


Do this:

![screen shot 2017-05-12 at 10 01 10 am](https://cloud.githubusercontent.com/assets/4116405/26001372/284e7f40-36fa-11e7-88e2-e3fa281e7fbe.png)
