### PR TITLE
Refs #19380 - adjust karma browserNoActivityTimeout

### DIFF
--- a/grunt/karma.js
+++ b/grunt/karma.js
@@ -6,7 +6,7 @@ module.exports = {
     options: {
         frameworks: ['jasmine'],
         runnerPort: 9100,
-        browserNoActivityTimeout: 30000,
+        browserNoActivityTimeout: 100000,
         colors: true,
         browsers: ['PhantomJS'],
         reporters: ['progress'],


### PR DESCRIPTION
the previous 30 seconds does not seem to be sufficient
using 100s just as patternfly does