### PR TITLE
fixes #20368 - Host Collection/Host views not filtering correctly

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -31,7 +31,7 @@
  */
 angular.module('Bastion.components').factory('Nutupane',
     ['$location', '$q', 'entriesPerPage', 'TableCache', 'GlobalNotification', function ($location, $q, entriesPerPage, TableCache, GlobalNotification) {
-        var Nutupane = function (resource, params, action) {
+        var Nutupane = function (resource, params, action, nutupaneParams) {
             var self = this;
 
             function getTableName() {
@@ -62,6 +62,8 @@ angular.module('Bastion.components').factory('Nutupane',
             params.page = $location.search().page || 1;
             params['per_page'] = $location.search()['per_page'] || entriesPerPage;
 
+            nutupaneParams = nutupaneParams || {};
+            self.disableAutoLoad = nutupaneParams.disableAutoLoad || false;
             self.searchKey = action ? action + 'Search' : 'search';
 
             self.table = {
@@ -464,8 +466,9 @@ angular.module('Bastion.components').factory('Nutupane',
                 self.table.searchTerm = $location.search()[self.searchKey];
             };
 
-            // Load initial set of results
-            self.load();
+            if (!self.disableAutoLoad) {
+                self.load();
+            }
         };
 
         return Nutupane;

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -459,5 +459,30 @@ describe('Factory: Nutupane', function() {
         });
     });
 
+    describe("Nutupane should", function() {
+
+        it("be able to disable auto-load", function() {
+            spyOn(Resource, 'customAction')
+            nutupane = new Nutupane(Resource, {}, 'customAction', {'disableAutoLoad': true});
+            expect(nutupane.disableAutoLoad).toBe(true);
+            expect(Resource.customAction).not.toHaveBeenCalled();
+        });
+
+        it("be able to load results after initialization", function() {
+            spyOn(Resource, 'customAction')
+            nutupane = new Nutupane(Resource, {}, 'customAction', {'disableAutoLoad': true});
+            expect(nutupane.disableAutoLoad).toBe(true);
+            nutupane.refresh();
+            expect(Resource.customAction).toHaveBeenCalled();
+        });
+
+        it("be able to enable autoload", function() {
+            spyOn(Resource, 'customAction')
+            nutupane = new Nutupane(Resource, {}, 'customAction', {'disableAutoLoad': false});
+            expect(nutupane.disableAutoLoad).toBe(false);
+            expect(Resource.customAction).toHaveBeenCalled();
+        });
+
+    });
 });
 


### PR DESCRIPTION
Adding a new flag overrideAutoLoad to control the initial loading behavior of the nutupane object.

This is required as in few use cases, we want to be able to set table parameters and adjust query parameters before loading the table. 