### PR TITLE
update angular-rails-templates to 1.0.2

### DIFF
--- a/bastion.gemspec
+++ b/bastion.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "angular-rails-templates", "0.1.2"
+  s.add_dependency "angular-rails-templates", "~> 1.0.2"
   s.add_development_dependency "uglifier"
 end


### PR DESCRIPTION
I can't really test this inside Katello, but the original issue should be fixed for a long time and according to the changelog, there were only additions of functionality and compatibility with newer Rails versions.