### PR TITLE
Fixes #20350 - Reset table refreshing state when fetching resource fails

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -140,6 +140,9 @@ angular.module('Bastion.components').factory('Nutupane',
                     table.working = false;
                     table.refreshing = false;
                     table.initialLoad = false;
+                }).$promise.catch(function() {
+                    table.working = false;
+                    table.refreshing = false;
                 });
 
                 return deferred.promise;


### PR DESCRIPTION
The table on Bastion pages were blocking subsequent searches when there was a server side error.

Simple fix but required some adjustments to the Nutupane tests due to the introduction of the promise which broke 40+ specs.