### PR TITLE
Fixes #20103: hide pagination controls if no pagination.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -343,6 +343,11 @@ angular.module('Bastion.components').factory('Nutupane',
                 self.table.resource.total += 1;
             };
 
+            self.table.hasPagination = function () {
+                return self.table.resource && self.table.resource.subtotal && self.table.resource.page &&
+                    self.table.resource.per_page && self.table.resource.offset;
+            };
+
             self.table.onFirstPage = function () {
                 return self.table.resource.page === 1;
             };

--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -70,7 +70,7 @@
         <div data-block="table"></div>
 
         <form class="content-view-pf-pagination table-view-pf-pagination clearfix">
-          <div class="form-group">
+          <div class="form-group" ng-show="table.hasPagination()">
             <div class="pagination-pf-pagesize">
               <select class="form-control" ng-model="table.params.per_page" ng-change="table.updatePageSize()"
                       ng-options="value for value in table.pageSizes">
@@ -78,7 +78,7 @@
             </div>
             <span translate>per page</span>
           </div>
-          <div class="form-group">
+          <div class="form-group" ng-show="table.hasPagination()">
             <span>
               <span class="pagination-pf-items-current" translate>Showing {{ table.getPageStart() }} - {{ table.getPageEnd() }}</span>
               <span translate>of </span>

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -203,6 +203,12 @@ describe('Factory: Nutupane', function() {
                expect(nutupane.table.numSelected).toBe(0);
         });
 
+        it("provides a way to check if the table supports pagination", function () {
+            expect(nutupane.table.hasPagination()).toBeTruthy();
+            nutupane.table.resource.subtotal = null;
+            expect(nutupane.table.hasPagination()).toBeFalsy();
+        });
+
         it("provides a way to tell if on the first page", function () {
             nutupane.table.firstPage();
             expect(nutupane.table.onFirstPage()).toBe(true);


### PR DESCRIPTION
If the API doesn't support pagination then we should not show the
pagination controls.

http://projects.theforeman.org/issues/20103