### PR TITLE
Fixes #20507: check if $promise exists on resource before using it.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -83,6 +83,7 @@ angular.module('Bastion.components').factory('Nutupane',
 
             self.load = function () {
                 var deferred = $q.defer(),
+                    resourceCall,
                     table = self.table,
                     existingTable = TableCache.getTable(getTableName());
 
@@ -100,8 +101,7 @@ angular.module('Bastion.components').factory('Nutupane',
                 params.search = table.searchTerm || "";
                 params.search = self.searchTransform(params.search);
 
-                resource[table.action](params, function (response) {
-
+                resourceCall = resource[table.action](params, function (response) {
                     if (response.error) {
                         GlobalNotification.setErrorMessage(response.error);
                     }
@@ -140,10 +140,14 @@ angular.module('Bastion.components').factory('Nutupane',
                     table.working = false;
                     table.refreshing = false;
                     table.initialLoad = false;
-                }).$promise.catch(function() {
-                    table.working = false;
-                    table.refreshing = false;
                 });
+
+                if (resourceCall && resourceCall.$promise && resourceCall.$promise.catch) {
+                    resourceCall.$promise.catch(function () {
+                        table.working = false;
+                        table.refreshing = false;
+                    });
+                }
 
                 return deferred.promise;
             };


### PR DESCRIPTION
We are now catching errors in the nutupane load function. In our tests
(and possibly in custom tranformResponse functions) there is not a
$promise object so we should check for it before using it.

http://projects.theforeman.org/issues/20507