### PR TITLE
Fixes #20530: ensure links in table are readable.

### DIFF
--- a/app/assets/stylesheets/bastion/tables.scss
+++ b/app/assets/stylesheets/bastion/tables.scss
@@ -31,11 +31,6 @@
   tr.focus td,
   tr.selected-row td {
     background-color: $hover-bg-color;
-    color: $hover-color;
-
-    > a {
-      color: $hover-color;
-    }
 
     button, select {
       color: #000;

--- a/app/assets/stylesheets/bastion/variables.scss
+++ b/app/assets/stylesheets/bastion/variables.scss
@@ -1,5 +1,5 @@
 $hover-color: #FFF;
-$hover-bg-color: rgb(0, 153, 211);
+$hover-bg-color: #def3ff;
 $label-color: #000;
 $border_color: #d7d7d7;
 $grid-gutter-width: 30px;


### PR DESCRIPTION
Links in highlighted rows weren't readable.  This commit fixes the links
so they are readable by changing the highlight color to the PF default.

http://projects.theforeman.org/issues/20530

Screenshots:

![screen shot 2017-08-15 at 2 55 10 pm](https://user-images.githubusercontent.com/4116405/29331267-d6fd82b0-81c9-11e7-8121-9f6dd1f84171.png)
![screen shot 2017-08-15 at 2 55 24 pm](https://user-images.githubusercontent.com/4116405/29331268-d712966e-81c9-11e7-9c09-798982a9def7.png)
