### PR TITLE
Fixes #20598: use state params for search.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -30,7 +30,7 @@
     </pre>
  */
 angular.module('Bastion.components').factory('Nutupane',
-    ['$location', '$q', 'entriesPerPage', 'TableCache', 'GlobalNotification', function ($location, $q, entriesPerPage, TableCache, GlobalNotification) {
+    ['$location', '$q', '$stateParams', 'entriesPerPage', 'TableCache', 'GlobalNotification', function ($location, $q, $stateParams, entriesPerPage, TableCache, GlobalNotification) {
         var Nutupane = function (resource, params, action, nutupaneParams) {
             var self = this;
 
@@ -71,14 +71,16 @@ angular.module('Bastion.components').factory('Nutupane',
                 params: params,
                 resource: resource,
                 rows: [],
-                searchTerm: $location.search()[self.searchKey] || "",
+                searchTerm: $stateParams[self.searchKey] || $location.search()[self.searchKey] || "",
                 initialLoad: true
             };
 
             self.loadParamsFromExistingTable = function (existingTable) {
                 params = existingTable.params;
                 self.table.params = existingTable.params;
-                self.table.searchTerm = existingTable.searchTerm;
+                if (!self.table.searchTerm) {
+                    self.table.searchTerm = existingTable.searchTerm;
+                }
             };
 
             self.load = function () {

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -1,6 +1,7 @@
 describe('Factory: Nutupane', function() {
     var $timeout,
         $location,
+        $stateParams,
         $rootScope,
         $q,
         Resource,
@@ -12,6 +13,8 @@ describe('Factory: Nutupane', function() {
     beforeEach(module('Bastion.components'));
 
     beforeEach(module(function ($provide) {
+        $stateParams = {};
+
         entriesPerPage = 20;
 
         TableCache = {
@@ -23,6 +26,7 @@ describe('Factory: Nutupane', function() {
             }
         };
 
+        $provide.value('$stateParams', $stateParams);
         $provide.value('entriesPerPage', entriesPerPage);
         $provide.value('TableCache', TableCache);
     }));


### PR DESCRIPTION
We should respect the state params for searches when an href is
generated with ui-sref. This commit ensures that $stateParams is
preferred over the table cache and what is in the query strings.

http://projects.theforeman.org/issues/20598