### PR TITLE
Refs #20732: Support subdirectory deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ A resource serves as a representation of an API endpoint for an entity and provi
      *   Defines the API endpoint for Content Host
      */
     function ContentHost(BastionResource) {
-          return BastionResource('/api/v2/content-hosts/:id/:action',
+          return BastionResource('api/v2/content-hosts/:id/:action',
               {id: '@uuid'},
               {
                   update: {method: 'PUT'},
@@ -170,7 +170,7 @@ A resource serves as a representation of an API endpoint for an entity and provi
 })();
 ```
 
-Here we have created an angular factory named `content-host` and attached it to the `Bastion.content-hosts` namespace. You can read more about the $resource service here - http://code.angularjs.org/1.0.7/docs/api/ngResource.$resource
+Here we have created an angular factory named `content-host` and attached it to the `Bastion.content-hosts` namespace. It's important that the resource URL does not begin with a '/' so that the application can live in a subdirectory without errors. You can read more about the $resource service here - http://code.angularjs.org/1.0.7/docs/api/ngResource.$resource
 
 #### Asset Pipeline
 

--- a/app/assets/javascripts/bastion/auth/auth.module.js
+++ b/app/assets/javascripts/bastion/auth/auth.module.js
@@ -58,14 +58,14 @@ angular.module('Bastion.auth').config(['$httpProvider', '$provide',
  * @name Bastion.auth.run
  *
  * @requires $rootScope
- * @requires $window
+ * @requires $location
  * @requires Authorization
  *
  * @description
  *   Check current user permissions and redirect to the 403 page if appropriate
  */
-angular.module('Bastion.auth').run(['$rootScope', '$window', 'Authorization',
-    function ($rootScope, $window, Authorization) {
+angular.module('Bastion.auth').run(['$rootScope', '$location', 'Authorization',
+    function ($rootScope, $location, Authorization) {
 
         function isAuthorized(permission) {
             return !(permission !== false && (angular.isUndefined(permission) || Authorization.denied(permission)));
@@ -83,7 +83,7 @@ angular.module('Bastion.auth').run(['$rootScope', '$window', 'Authorization',
             });
 
             if (angular.isUndefined(permitted)) {
-                $window.location.href = '/katello/403';
+                $location.path('/katello/403');
             }
         });
 

--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -31,10 +31,13 @@ angular.module('Bastion').config(
         $provide.factory('PrefixInterceptor', ['$q', '$templateCache', function ($q, $templateCache) {
             return {
                 request: function (config) {
+                    var relativeUrl = BastionConfig.relativeUrlRoot;
                     if (config.url.indexOf('.html') !== -1) {
                         if (angular.isUndefined($templateCache.get(config.url))) {
-                            config.url = '/' + config.url;
+                            config.url = relativeUrl + config.url;
                         }
+                    } else {
+                        config.url = relativeUrl + config.url;
                     }
 
                     return config || $q.when(config);
@@ -73,12 +76,13 @@ angular.module('Bastion').config(
  * @requires $breadcrumb
  * @requires PageTitle
  * @requires markActiveMenu
+ * @requires BastionConfig
  *
  * @description
  *   Set up some common state related functionality and set the current language.
  */
-angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', '$breadcrumb', 'PageTitle', 'markActiveMenu',
-    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, $breadcrumb, PageTitle, markActiveMenu) {
+angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', '$breadcrumb', 'PageTitle', 'markActiveMenu', 'BastionConfig',
+    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, $breadcrumb, PageTitle, markActiveMenu, BastionConfig) {
         var fromState, fromParams, orgSwitcherRegex;
 
         $rootScope.$state = $state;
@@ -107,7 +111,7 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
         };
 
         $rootScope.taskUrl = function (taskId) {
-            return "/foreman_tasks/tasks/" + taskId;
+            return BastionConfig.relativeUrlRoot + "/foreman_tasks/tasks/" + taskId;
         };
 
         // Set the current language

--- a/app/assets/javascripts/bastion/components/bst-bookmark.factory.js
+++ b/app/assets/javascripts/bastion/components/bst-bookmark.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.components').factory('BstBookmark',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/bookmarks', {id: '@id'},
+        return BastionResource('api/v2/bookmarks', {id: '@id'},
             {
                 create: { method: 'POST' }
             }

--- a/app/controllers/bastion/bastion_controller.rb
+++ b/app/controllers/bastion/bastion_controller.rb
@@ -2,6 +2,9 @@ module Bastion
   class BastionController < ::ApplicationController
     skip_before_filter :authorize
 
+    # prevent Foreman routes from being incorrectly generated (don't use the Bastion url_helpers)
+    include Rails.application.routes.url_helpers
+
     def index
       render 'bastion/layouts/application', :layout => false
     end

--- a/app/views/bastion/layouts/assets.html.erb
+++ b/app/views/bastion/layouts/assets.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:head) do %>
+  <base href="<%= Bastion.config['relativeUrlRoot'] %>" />
+<% end %>
+
 <% content_for(:stylesheets) do %>
   <%= stylesheet_link_tag "bastion/bastion" %>
   <% Bastion.plugins.each do |name, plugin| %>

--- a/lib/bastion.rb
+++ b/lib/bastion.rb
@@ -17,8 +17,10 @@ module Bastion
   end
 
   def self.config
+    url_root = ENV['RAILS_RELATIVE_URL_ROOT']
     base_config = {
-      'markTranslated' => SETTINGS[:mark_translated] || false
+      'markTranslated' => SETTINGS[:mark_translated] || false,
+      'relativeUrlRoot' => url_root ? url_root + '/' : '/'
     }
 
     Bastion.plugins.each do |name, plugin|

--- a/test/bastion-config.test.js
+++ b/test/bastion-config.test.js
@@ -1,0 +1,39 @@
+var BastionConfig,
+    PrefixInterceptor;
+
+describe('PrefixInterceptor', function() {
+    beforeEach(module('gettext'));
+    beforeEach(module('Bastion'));
+
+    beforeEach(inject(function(_PrefixInterceptor_, _BastionConfig_) {
+        PrefixInterceptor = _PrefixInterceptor_;
+        BastionConfig = _BastionConfig_;
+    }));
+
+    describe('uncached template URL and no relativeUrlRoot', function() {
+        it('prepends / to config.url', function() {
+            var result = PrefixInterceptor.request({ url: 'template.html'});
+            expect(result.url).toBe('/template.html');
+        });
+    });
+
+    describe('relativeUrlRoot configured', function() {
+        beforeEach(function() {
+          BastionConfig.relativeUrlRoot = '/foreman/';
+        });
+
+        describe('uncached template URL', function() {
+            it('prepends the relative URL prefix', function() {
+                var result = PrefixInterceptor.request({ url: 'template.html'});
+                expect(result.url).toBe('/foreman/template.html');
+            });
+        });
+
+        describe('non-template URL', function() {
+            it('prepends the relative URL prefix', function() {
+                var result = PrefixInterceptor.request({ url: 'api/v2/hosts'});
+                expect(result.url).toBe('/foreman/api/v2/hosts');
+            });
+        });
+    });
+});

--- a/test/bastion/test-constants.js
+++ b/test/bastion/test-constants.js
@@ -3,11 +3,13 @@ angular.module('Bastion').value('currentLocale', 'Here');
 angular.module('Bastion').value('CurrentOrganization', "ACME");
 angular.module('Bastion').value('Authorization', {});
 angular.module('Bastion').value('entriesPerPage', 20);
+angular.module('Bastion').value('PageTitle', 'Bastion Page');
 angular.module('Bastion').value('markActiveMenu', function () {});
 angular.module('Bastion').value('foreman', function () {});
 angular.module('Bastion').constant('BastionConfig', {
     consumerCertRPM: "consumer_cert_rpm",
-    markTranslated: false
+    markTranslated: false,
+    relativeUrlRoot: '/'
 });
 angular.module('Bastion.auth').value('CurrentUser', {id: "User"});
 angular.module('Bastion.auth').value('Permissions', []);


### PR DESCRIPTION
This is only half of the change - there are changes required to each BastionResource in Katello and that'll be coming shortly. They do in fact need to be released together despite what I wrote here previously.

Few challenges:

- There is a *lot* of discussion in Rails and Angular communities on how to deploy those respective frameworks in subdirectories. At the end of the day we are constrained to the way [Foreman is doing it](https://github.com/theforeman/foreman/blob/1a0f69e7aac2e07fd438ca5ee3c2ef297b504242/config.ru#L6-L7).
- Lots (in katello) of BastionResource URLs prefixed with '/' which prevents 
-A bunch of templates broke thus the changes in the Bastion module
- Some Foreman routes present in Bastion layout were broken due to the way routes work within a rails engine. See comments inline.