### PR TITLE
Fixes #20481: Missing params on api call

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -76,7 +76,7 @@ angular.module('Bastion.components').factory('Nutupane',
             };
 
             self.loadParamsFromExistingTable = function (existingTable) {
-                params = existingTable.params;
+                _.extend(params, existingTable.params);
                 self.table.params = existingTable.params;
                 if (!self.table.searchTerm) {
                     self.table.searchTerm = existingTable.searchTerm;


### PR DESCRIPTION
The code was just dropping params rather than including the existing
global commands.

http://projects.theforeman.org/issues/20481