### PR TITLE
Fixes #19949: URL updating with modal changes

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -39,6 +39,11 @@ angular.module('Bastion.components').factory('Nutupane',
             }
 
             function setQueryStrings() {
+                // Don't manipulate the query string for params of a modal view
+                if (document.body.className.indexOf("modal-open") >= 0) {
+                    return;
+                }
+
                 if (self.table.params.paged) {
                     $location.search("page", self.table.params.page).replace();
                     $location.search("per_page", self.table.params['per_page']).replace();


### PR DESCRIPTION
This keeps the URL from updating when change pagination options in a
modal. The modal state should be isolated and not update the URL.

http://projects.theforeman.org/issues/19949