### PR TITLE
Fixes #21035: Resource switcher intercepts focus

### DIFF
--- a/app/assets/javascripts/bastion/components/views/bst-resource-switcher.html
+++ b/app/assets/javascripts/bastion/components/views/bst-resource-switcher.html
@@ -1,5 +1,5 @@
 <span uib-dropdown ng-show="table.rows" on-toggle="toggled(open)">
-  <a href uib-dropdown-toggle>
+  <a uib-dropdown-toggle>
     <i class="fa fa-exchange"></i>
   </a>
   <ul class="dropdown-menu" uib-dropdown-menu>


### PR DESCRIPTION
The uib-dropdown has a bug where the focus gets stuck if you
have an anchor tag with an href attribute and uib-dropdown-toggle.
Removing the href solves the issue.

http://projects.theforeman.org/issues/21035