### PR TITLE
Fixes #21144: remove mark_active_menu from bastion.

### DIFF
--- a/app/assets/javascripts/bastion/bastion.module.js
+++ b/app/assets/javascripts/bastion/bastion.module.js
@@ -75,14 +75,13 @@ angular.module('Bastion').config(
  * @requires $window
  * @requires $breadcrumb
  * @requires PageTitle
- * @requires markActiveMenu
  * @requires BastionConfig
  *
  * @description
  *   Set up some common state related functionality and set the current language.
  */
-angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', '$breadcrumb', 'PageTitle', 'markActiveMenu', 'BastionConfig',
-    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, $breadcrumb, PageTitle, markActiveMenu, BastionConfig) {
+angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', '$breadcrumb', 'PageTitle', 'BastionConfig',
+    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, $breadcrumb, PageTitle, BastionConfig) {
         var fromState, fromParams, orgSwitcherRegex;
 
         $rootScope.$state = $state;
@@ -129,9 +128,6 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
                 if (PageTitle.titles.length > 1) {
                     PageTitle.resetToFirst();
                 }
-
-                //Set the active menu item in Foreman
-                markActiveMenu();
             }
         );
 

--- a/app/views/bastion/layouts/assets.html.erb
+++ b/app/views/bastion/layouts/assets.html.erb
@@ -22,7 +22,6 @@
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
     angular.module('Bastion').value('contentAccessMode', "<%= Organization.current.try(:content_access_mode) if Organization.current %>");
     angular.module('Bastion').value('foreman', tfm);
-    angular.module('Bastion').value('markActiveMenu', mark_active_menu);
     angular.module('Bastion').value('entriesPerPage', "<%= Setting[:entries_per_page] %>");
     angular.module('Bastion').constant('BastionConfig', angular.fromJson('<%= Bastion.config.to_json.html_safe %>'));
     angular.module('Bastion.auth').value('CurrentUser', {

--- a/test/bastion/test-constants.js
+++ b/test/bastion/test-constants.js
@@ -4,7 +4,6 @@ angular.module('Bastion').value('CurrentOrganization', "ACME");
 angular.module('Bastion').value('Authorization', {});
 angular.module('Bastion').value('entriesPerPage', 20);
 angular.module('Bastion').value('PageTitle', 'Bastion Page');
-angular.module('Bastion').value('markActiveMenu', function () {});
 angular.module('Bastion').value('foreman', function () {});
 angular.module('Bastion').constant('BastionConfig', {
     consumerCertRPM: "consumer_cert_rpm",


### PR DESCRIPTION
The mark_active_menu function was removed from foreman with vertical
navigation. We should remove the usages of this from bastion as it
causes a JS error on all bastion pages

http://projects.theforeman.org/issues/21144