### PR TITLE
Fixes #21054: Hide resource switcher on new

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-resource-switcher.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-resource-switcher.directive.js
@@ -30,6 +30,18 @@
                     scope.table = TableCache.getTable(getTableName(listUrl));
                 }
 
+                scope.showSwitcher = function () {
+                    var tableHasRows, isNewPage;
+
+                    // Must have at least two items to switch between them
+                    tableHasRows = scope.table && scope.table.rows.length > 1;
+
+                    // Don't show the switcher when creating a new product
+                    isNewPage = /new$/.test($location.path());
+
+                    return tableHasRows && !isNewPage;
+                };
+
                 scope.changeResource = function (id) {
                     var currentUrl, nextUrl;
                     currentUrl = $location.path();

--- a/app/assets/javascripts/bastion/components/views/bst-resource-switcher.html
+++ b/app/assets/javascripts/bastion/components/views/bst-resource-switcher.html
@@ -1,4 +1,4 @@
-<span uib-dropdown ng-show="table.rows" on-toggle="toggled(open)">
+<span uib-dropdown ng-show="showSwitcher()" on-toggle="toggled(open)">
   <a uib-dropdown-toggle>
     <i class="fa fa-exchange"></i>
   </a>


### PR DESCRIPTION
The resource switcher should not be available when there is not
another resource to switch to or when creating a new resource.

http://projects.theforeman.org/issues/21054