### PR TITLE
Fixes #21311 - Allow adding multiple js and style tags from plugins

### DIFF
--- a/app/controllers/bastion/bastion_controller.rb
+++ b/app/controllers/bastion/bastion_controller.rb
@@ -1,5 +1,6 @@
 module Bastion
   class BastionController < ::ApplicationController
+    helper 'bastion/layout'
     skip_before_filter :authorize
 
     # prevent Foreman routes from being incorrectly generated (don't use the Bastion url_helpers)

--- a/app/helpers/bastion/layout_helper.rb
+++ b/app/helpers/bastion/layout_helper.rb
@@ -1,0 +1,27 @@
+module Bastion
+  module LayoutHelper
+    def include_plugin_js(plugin)
+      return unless plugin[:javascript]
+
+      if plugin[:javascript].is_a?(Proc)
+        js = instance_eval(&plugin[:javascript])
+        js = js.join("\n") if js.is_a?(Array)
+        js.html_safe
+      else
+        javascript_include_tag(plugin[:javascript])
+      end
+    end
+
+    def include_plugin_styles(plugin)
+      return unless plugin[:stylesheet]
+
+      if plugin[:stylesheet].is_a?(Proc)
+        styles = instance_eval(&plugin[:stylesheet])
+        styles = styles.join("\n") if styles.is_a?(Array)
+        styles.html_safe
+      else
+        stylesheet_link_tag(plugin[:stylesheet])
+      end
+    end
+  end
+end

--- a/app/views/bastion/layouts/assets.html.erb
+++ b/app/views/bastion/layouts/assets.html.erb
@@ -5,9 +5,7 @@
 <% content_for(:stylesheets) do %>
   <%= stylesheet_link_tag "bastion/bastion" %>
   <% Bastion.plugins.each do |name, plugin| %>
-    <% if plugin[:stylesheet] %>
-      <%= stylesheet_link_tag(plugin[:stylesheet]) %>
-    <% end %>
+    <%= include_plugin_styles(plugin) %>
   <% end %>
 <% end %>
 
@@ -32,7 +30,7 @@
     angular.module('Bastion.auth').value('Permissions', angular.fromJson('<%= User.current.cached_roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>'));
   </script>
   <% Bastion.plugins.each do |name, plugin| %>
-    <%= javascript_include_tag(plugin[:javascript]) %>
+    <%= include_plugin_js(plugin) %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Adds possbility to specify :javascript and :stylesheet as a proc that is lazily evaluated from the assets layout.

Eg.:
```ruby
Bastion.register_plugin(
  :name => 'bastion_katello',
  :javascript => Proc.new {
    [
      # adds webpack live server
      javascript_include_tag(*webpack_asset_paths('katello', :extension => 'js'), "data-turbolinks-track" => true),
      javascript_include_tag('bastion_katello/bastion_katello')
    ]
  },
  # ...
```