### PR TITLE
Fixes #21631 - Set root for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "eslintConfig": {
+    "root": true
+  },
   "main": "./bastion.js",
   "directories": {
     "lib": "./grunt"


### PR DESCRIPTION
Setting the root for eslint so it stops cascading.
See https://eslint.org/docs/user-guide/configuring

http://projects.theforeman.org/issues/21631