### PR TITLE
Fixes #21632 - Move root to eslint.yaml

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -1,4 +1,6 @@
 ---
+root: true
+
 plugins:
   - angular
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   "engines": {
     "node": ">=0.8.0"
   },
-  "eslintConfig": {
-    "root": true
-  },
   "main": "./bastion.js",
   "directories": {
     "lib": "./grunt"


### PR DESCRIPTION
Moving the root flag from package.json to eslint.yaml

http://projects.theforeman.org/issues/21632