### PR TITLE
fixes #22118 - Replace skip_before_filter with skip_before_action for Rails 5

### DIFF
--- a/app/controllers/bastion/bastion_controller.rb
+++ b/app/controllers/bastion/bastion_controller.rb
@@ -1,7 +1,7 @@
 module Bastion
   class BastionController < ::ApplicationController
     helper 'bastion/layout'
-    skip_before_filter :authorize
+    skip_before_action :authorize
 
     # prevent Foreman routes from being incorrectly generated (don't use the Bastion url_helpers)
     include Rails.application.routes.url_helpers


### PR DESCRIPTION
This makes Katello work for me again on the latest develop.