### PR TITLE
Fixes #22134: fix next page not working.

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -421,6 +421,7 @@ angular.module('Bastion.components').factory('Nutupane',
 
             self.table.changePage = function (pageNumber) {
                 if (pageNumber && self.table.pageExists(pageNumber)) {
+                    self.invalidate();
                     params.page = pageNumber;
                     self.table.resource.page = pageNumber;
                     return self.load();


### PR DESCRIPTION
The next page button was not working on the errata page (and
potentially others).  This commit ensures that the table cache
is invalidated when changing pages.

http://projects.theforeman.org/issues/22134