### PR TITLE
Fixes #23120 - CV Add on Composite CV refresh issue

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -81,7 +81,7 @@ angular.module('Bastion.components').factory('Nutupane',
             };
 
             self.loadParamsFromExistingTable = function (existingTable) {
-                _.extend(params, existingTable.params);
+                _.extend(existingTable.params, params);
                 self.table.params = existingTable.params;
                 if (!self.table.searchTerm) {
                     self.table.searchTerm = existingTable.searchTerm;


### PR DESCRIPTION
## Steps to Reproduce the current reported issue:
1. Create a new Content View
2. Create a new CCV
3. Add the CV in CCV
4. Remove the CV from the CCV.
4. The CV will not be on the Add list. 
There are several other flows which would cause the same issue.

In the method loadParamsFromExistingTable we could either assign self.table.params to params or make existingTable.params the target param for the _.extend method.