### PR TITLE
Fixes #23434 - Show/Hide Resource Switcher and fix duplicate Id error

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-resource-switcher.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-resource-switcher.directive.js
@@ -31,15 +31,14 @@
                 }
 
                 scope.showSwitcher = function () {
-                    var tableHasRows, isNewPage;
-
+                    var tableHasRows, isNewPage, hideSwitcher;
                     // Must have at least two items to switch between them
                     tableHasRows = scope.table && scope.table.rows.length > 1;
-
+                    hideSwitcher = scope.hideSwitcher;
                     // Don't show the switcher when creating a new product
                     isNewPage = /new$/.test($location.path());
 
-                    return tableHasRows && !isNewPage;
+                    return tableHasRows && !isNewPage && !hideSwitcher;
                 };
 
                 scope.changeResource = function (id) {
@@ -50,7 +49,7 @@
                 };
 
                 unregisterWatcher = scope.$watch('table.rows', function (rows) {
-                    var currentId = parseInt($location.path().match(/\d+/)[0], 10);
+                    var currentId = $location.path().match(/\d+/) ? parseInt($location.path().match(/\d+/)[0], 10) : null;
 
                     angular.forEach(rows, function (row) {
                         if (row.id === currentId) {

--- a/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -97,11 +97,7 @@
               </li>
             </ul>
 
-            <label for="currentPage" class="sr-only" translate>
-              Current Page
-            </label>
-
-            <input id="currentPage" ng-show="table.resource.subtotal > 0" class="pagination-pf-page" type="text" ng-model="table.params.page"
+            <input ng-show="table.resource.subtotal > 0" class="pagination-pf-page" type="text" ng-model="table.params.page"
                    ng-blur="table.changePage(table.params.page)" bst-on-enter="table.changePage(table.params.page)"/>
 
             <input ng-show="table.resource.subtotal === 0" class="pagination-pf-page" type="text" readonly="true" ng-value="table.resource.subtotal"/>

--- a/test/components/bst-resource-switcher.directive.test.js
+++ b/test/components/bst-resource-switcher.directive.test.js
@@ -35,7 +35,7 @@ describe('Directive: bstResourceSwitcher', function() {
         TableCache = {
             getTable: function () {}
         };
-
+        hideSwitcher = true;
         $provide.value('translateFilter',  function(a) { return a; });
         $provide.value('$breadcrumb', $breadcrumb);
         $provide.value('$location', $location);
@@ -82,6 +82,28 @@ describe('Directive: bstResourceSwitcher', function() {
             scope.changeResource(2);
 
             expect($location.path).toHaveBeenCalledWith('/fake/2');
+        });
+
+        it("be able to show the resource switcher", function () {
+            createDirective();
+            scope.table = {
+                rows : {
+                    length : 5
+                }
+            };
+            scope.hideSwitcher = false;
+            expect(scope.showSwitcher()).toBe(true);
+        });
+
+        it("be able to hide the resource switcher", function () {
+            createDirective();
+            scope.table = {
+                rows : {
+                    length : 5
+                }
+            };
+            scope.hideSwitcher = true;
+            expect(scope.showSwitcher()).toBe(false);
         });
     });
 });


### PR DESCRIPTION
Tracking 3 related issues here:
1. Provide ability to show/hide Resource Switcher. (For pages where breadcrumb is needed but the resource switcher is not. Ex: Repo Discovery)
2. Fix _"[DOM] Found 2 elements with non-unique id #currentPage"_ console error on certain pages on the input box **_Page number_** of total Page (Example Product> Repo Discovery)
3. Fix _"TypeError: Cannot read property '0' of null"_ on pages where path doesn't have ids (Example Product> Repo Discovery, Content Host> Register)