### PR TITLE
Fixes #24725 - need to set nutupane params correctly

### DIFF
--- a/app/assets/javascripts/bastion/bastion-bootstrap.js
+++ b/app/assets/javascripts/bastion/bastion-bootstrap.js
@@ -1,4 +1,4 @@
-  angular.element(document).ready(function () {
+angular.element(document).ready(function () {
     angular.bootstrap(document, BASTION_MODULES);
 });
 

--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -82,7 +82,7 @@ angular.module('Bastion.components').factory('Nutupane',
 
             self.loadParamsFromExistingTable = function (existingTable) {
                 _.extend(existingTable.params, params);
-                self.table.params = existingTable.params;
+                self.params = existingTable.params;
                 if (!self.table.searchTerm) {
                     self.table.searchTerm = existingTable.searchTerm;
                 }


### PR DESCRIPTION
This is related to PR: https://github.com/Katello/bastion/pull/227.

The issue is that the new changes do not update the nutupane params with the table params. 
The issue presents itself on the repository sets tab on content host and activation keys.

For more details, see : https://github.com/Katello/katello/pull/7652

## Steps to Reproduce:

- Go to activation key / Content Host
- Go to Repository sets tab. (You should see records if there are subscriptions attached)
- Click on show all.
- All repository sets are not displayed, especially if you go to some other tab on the page and come back.

