### PR TITLE
Fixes #24729 - Allow edit trigger on text etc

### DIFF
--- a/app/assets/javascripts/bastion/bastion-bootstrap.js
+++ b/app/assets/javascripts/bastion/bastion-bootstrap.js
@@ -1,4 +1,4 @@
-  angular.element(document).ready(function () {
+angular.element(document).ready(function () {
     angular.bootstrap(document, BASTION_MODULES);
 });
 

--- a/app/assets/javascripts/bastion/components/bst-edit.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-edit.directive.js
@@ -138,6 +138,8 @@ angular.module('Bastion.components')
         $scope.$watch('editTrigger', function (edit) {
             if (edit) {
                 $scope.edit();
+            } else {
+                $scope.editMode = false;
             }
         });
 
@@ -174,7 +176,9 @@ angular.module('Bastion.components')
                 handleSave: '&onSave',
                 handleCancel: '&onCancel',
                 deletable: '@deletable',
-                handleDelete: '&onDelete'
+                handleDelete: '&onDelete',
+                editTrigger: '=',
+                forcedWorkingMode: '='
             },
             templateUrl: 'components/views/bst-edit-text.html'
         };
@@ -247,7 +251,8 @@ angular.module('Bastion.components')
                 handleCancel: '&onCancel',
                 deletable: '=deletable',
                 handleDelete: '&onDelete',
-                editTrigger: '='
+                editTrigger: '=',
+                forcedWorkingMode: '='
             },
             templateUrl: 'components/views/bst-edit-select.html',
             compile: function (element, attrs) {


### PR DESCRIPTION
We are adding editTrigger to text field and forcedWorkingMode to bst-edit-select.

We need these for some UI changes needed for https://github.com/Katello/katello/pull/7644