### PR TITLE
Fixes #25047 - Notification link

### DIFF
--- a/app/assets/javascripts/bastion/components/notification.service.js
+++ b/app/assets/javascripts/bastion/components/notification.service.js
@@ -16,8 +16,15 @@ angular.module('Bastion.components').service("Notification", ['$interpolate', 'f
         return result;
     }
 
-    this.setSuccessMessage = function (message, context) {
-        foreman.toastNotifications.notify({message: interpolateIfNeeded(message, context), type: 'success'});
+    this.setSuccessMessage = function (message, options) {
+        var baseOptions, fullOptions;
+        /* eslint-disable no-unused-expressions */
+        (angular.isUndefined(options)) && (options = {});
+        /* eslint-enable no-unused-expressions */
+        baseOptions = { message: interpolateIfNeeded(message, options.context), type: 'success' };
+        delete options.context;
+        fullOptions = _.extend(baseOptions, options);
+        foreman.toastNotifications.notify(fullOptions);
     };
 
     this.setWarningMessage = function (message, context) {

--- a/test/components/notification.service.test.js
+++ b/test/components/notification.service.test.js
@@ -38,10 +38,17 @@ describe('Factory: Nofification', function() {
 
     it("allows message context to be specified for interpolation", function () {
         var message = "Everything ran correctly {{ ending }}!",
-            $scope = {ending: 'yay'},
+            options = {link: "", context: {ending: 'yay'}},
             expectedMessage = 'Everything ran correctly yay!';
 
-        Notification.setSuccessMessage(message, $scope);
-        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: expectedMessage, type: 'success'});
+        Notification.setSuccessMessage(message, options);
+        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: expectedMessage, type: 'success', link: options.link});
+    });
+
+    it("provides link to success task", function () {
+        var message = "Everything ran correctly!";
+        options = {link: "www.redhat.com"};
+        Notification.setSuccessMessage(message, options);
+        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: message, type: 'success', link: options.link});
     });
 });


### PR DESCRIPTION
This is my first attempt at fixing this code. I'm getting it to work correctly to fix the issue, but it's causing some weird problems with other success notification windows. It seems to stall the process of showing the notification window and any action after that.

Also, I'm getting hung up with the tests that I wrote. I'm unsure of how to pass the parameters correctly and use the default parameters when only a message is passed to the function. Failing tests look like so: 

```
PhantomJS 2.1.1 (Linux 0.0.0) Factory: Nofification provides a way to set success messages FAILED
	TypeError: undefined is not an object (evaluating 'options.context') in /home/vagrant/bastion/app/assets/javascripts/bastion/components/notification.service.js (line 9)
	setSuccessMessage@/home/vagrant/bastion/app/assets/javascripts/bastion/components/notification.service.js:9:1073
	/home/vagrant/bastion/test/components/notification.service.test.js:35:39
PhantomJS 2.1.1 (Linux 0.0.0) Factory: Nofification allows message context to be specified for interpolation FAILED
	Expected spy notify to have been called with [ Object({ message: 'Everything ran correctly yay!', type: 'success', link: '' }) ] but actual calls were [ Object({ message: 'Everything ran correctly {{ ending }}!', type: 'success', link: '' }) ].
	/home/vagrant/bastion/test/components/notification.service.test.js:46:71

```