### PR TITLE
Fixes #25083 - Ignore missing ids when checking previous values

### DIFF
--- a/app/assets/javascripts/bastion/components/bst-edit.directive.js
+++ b/app/assets/javascripts/bastion/components/bst-edit.directive.js
@@ -287,12 +287,17 @@ angular.module('Bastion.components')
 
         getIds = function (models) {
             models = models || [];
-            return _.map(models, "id");
+            return _.chain(models).map("id").without(undefined).value();
         };
 
         checkPrevious = function () {
+            var appliedIds = getIds($scope.model);
+
+            if (_.isEmpty(appliedIds)) {
+                return;
+            }
+
             _.each($scope.options, function (tag) {
-                var appliedIds = getIds($scope.model);
                 if (_.includes(appliedIds, tag.id, 0)) {
                     tag.selected = true;
                 } else {


### PR DESCRIPTION
From the katello side we are looking at values which don't have ids:
```
[
  {name: 'EUS', selected: true}
]
```

This change makes it so checkprevious won't attempt to process values like this so the code will honor the given 'selected' value. We could also opt to remove the checkPrevious stuff altogether since it's used in just one  place in Katello where were aren't relying on it - but this preserves existing behavior in the test.