### PR TITLE
Fixes #24554: Xtnd params not existingTable.params

### DIFF
--- a/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -81,8 +81,7 @@ angular.module('Bastion.components').factory('Nutupane',
             };
 
             self.loadParamsFromExistingTable = function (existingTable) {
-                _.extend(existingTable.params, params);
-                self.params = existingTable.params;
+                _.extend(params, existingTable.params);
                 if (!self.table.searchTerm) {
                     self.table.searchTerm = existingTable.searchTerm;
                 }

--- a/test/components/nutupane.factory.test.js
+++ b/test/components/nutupane.factory.test.js
@@ -114,6 +114,13 @@ describe('Factory: Nutupane', function() {
                 expect($location.search).toHaveBeenCalledWith('per_page', 20);
             });
 
+            it("from existing table", function () {
+                table = {params: {per_page: 30}};
+                expect(nutupane.table.params.per_page).toBe(20);
+                nutupane.loadParamsFromExistingTable(table);
+                expect(nutupane.table.params.per_page).toBe(30);
+            });
+
             it("but does not include page information if not paged", function () {
                 nutupane.table.params.paged = false;
                 nutupane.load();


### PR DESCRIPTION
It appears we were misusing `_.extend`: https://lodash.com/docs/4.17.10#assignIn

We want to update the params, not the existingTable.params (the existingTable.params have the recently user-input per_page value).

Note how the test fails without the code change.

Note also that your queries are now saved on each table. If you set a per_page of 25 and `search='name~c'` on package list, then click the errata tab, set per_page to something, and then go back to the packages table, all your params are still set!