### PR TITLE
Fixes #25372 - Restore .editable-value class

### DIFF
--- a/app/assets/stylesheets/bastion/forms.scss
+++ b/app/assets/stylesheets/bastion/forms.scss
@@ -37,3 +37,7 @@
   height: auto;
   max-width: 100%;
 }
+
+.editable-value {
+  white-space: pre-line;
+}


### PR DESCRIPTION
I removed the .editable-value class from the stylesheet when working on system purpose since it was distorting the view with the additional changes I was making - this broke the display of GPG keys under Content Credentials as a result.

Adding this class back not only fixes the GPG key display, but it seems to have no issue with the System Purpose display on Content Host Details which I had observed earlier...

### testing

create a content credential for a GPG key such as https://getfedora.org/static/429476B4.txt
Observe that viewing the key results in the newlines not being properly respected

Applying the patch will correct the problem and the key will display as it is in the above .txt

The local bastion setup can be achieved like this for a bastion checkout in /home/vagrant/bastion
```
[vagrant@centos7-devel foreman]$ pwd
/home/vagrant/foreman
[vagrant@centos7-devel foreman]$ cat ./bundler.d/bastion.local.rb 
gemspec :path => '../bastion',  :name => 'bastion'
```
